### PR TITLE
Fix AttributeError when calling isUnlimited()

### DIFF
--- a/Packages/cdms2/Lib/axis.py
+++ b/Packages/cdms2/Lib/axis.py
@@ -1972,8 +1972,8 @@ class FileAxis(AbstractAxis):
 
     def isUnlimited(self):
         "Return true iff the axis is 'Unlimited' (extensible)"
-        if self.parent is not None and self.parent.dimensions.has_key(self.id):
-            return (self.parent.dimensions[self.id] is None)
+        if self.parent is not None and self.parent._file_.dimensions.has_key(self.id):
+            return (self.parent._file_.dimensions[self.id] is None)
         else:
             return False
 ## PropertiedClasses.set_property (FileAxis, 'units', 


### PR DESCRIPTION
This has been fixed for some time in cdat_lite.  An example test which exposes
the bug would be as follows (assuming ncfile exists with variable 'climseas'):

```
def test_dimension_isUnlimeted():
    f = cdms2.open(ncfile)
    try:
        v = f.variables['climseas']
        t = v.getTime()

        # fails with AttributeError: CdmsFile.dimensions
        assert t.isUnlimited()
    finally:
        f.close()
```
