### PR TITLE
Revert "Fixed GUI color map update (HACK)"

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -234,7 +234,6 @@ class VTKVCSBackend(object):
       return ren
 
   def update(self, *args, **kargs):
-      self._lastSize = -1
       if self.renWin:
           self.configureEvent(None,None)
 


### PR DESCRIPTION
Reverts UV-CDAT/uvcdat#744. Let's wait until somebdy that is NOT the autohr reviews and merges. I think there is a better way to fix this.
