### PR TITLE
Fixing UVCDAT runtime environment

### DIFF
--- a/CMake/cdat_modules_extra/cdat.in
+++ b/CMake/cdat_modules_extra/cdat.in
@@ -1,0 +1,4 @@
+#!/bin/bash
+# source is not portable whereas . is
+. "@CMAKE_INSTALL_PREFIX@/bin/setup_runtime.sh"
+python@PYVER@ "$@"

--- a/CMake/cdat_modules_extra/setup_runtime.csh.in
+++ b/CMake/cdat_modules_extra/setup_runtime.csh.in
@@ -1,5 +1,3 @@
-#!/bin/csh
-
 # Main install prefix set by user or post install script:
 # UVCDAT_INSTALL_PREFIX
 

--- a/CMake/cdat_modules_extra/setup_runtime.sh.in
+++ b/CMake/cdat_modules_extra/setup_runtime.sh.in
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-# Main install prefix set by user or post install script:
-# UVCDAT_INSTALL_PREFIX
-
-# If unset, use the value configured by cmake by default.
 # Everything beyond this point will be determined relatively
 # from this path.
-install_prefix="${UVCDAT_INSTALL_PREFIX:-@CMAKE_INSTALL_PREFIX@}"
+install_prefix="@CMAKE_INSTALL_PREFIX@"
 
 function cleanup {
   unset cleanup install_prefix library_paths python_paths executable_paths
@@ -16,12 +12,14 @@ function cleanup {
 # which can lead to errors.
 if [ -n "${UVCDAT_SETUP_PATH}" ] ; then
   if [ "${UVCDAT_SETUP_PATH}" = "${install_prefix}" ] ; then
-    echo "UVCDAT setup already sourced for this install location." 1>&2
+    echo "WARNING: UVCDAT setup already sourced for this install location." 1>&2
+    echo "WARNING: You shouldn't source setup_runtime anymore." 1>&2
     cleanup
-    return 1
+    return 0
   else
     echo "ERROR: UVCDAT setup was previously sourced at \"${UVCDAT_SETUP_PATH}\"" 1>&2
-    echo "Open a new shell in order to use a different install location." 1>&2
+    echo "ERROR: There is no need to run setup_runtime manually anymore." 1>&2
+    echo "ERROR: Open a new shell in order to use a different install location." 1>&2
     cleanup
     return 1
   fi
@@ -59,6 +57,7 @@ for d in "${python_paths[@]}" ; do
   if [ -d "${f}" ] ; then
     PYTHONPATH="${f}:${PYTHONPATH}"
   fi
+  unset f
 done
 
 for d in "${executable_paths[@]}" ; do
@@ -66,6 +65,7 @@ for d in "${executable_paths[@]}" ; do
   if [ -d "${f}" ] ; then
     PATH="${f}:${PATH}"
   fi
+  unset f
 done
 
 if [ -d "${install_prefix}/Externals/lib/R" ] ; then

--- a/CMake/cdat_modules_extra/setup_runtime.sh.in
+++ b/CMake/cdat_modules_extra/setup_runtime.sh.in
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Everything beyond this point will be determined relatively
 # from this path.
 install_prefix="@CMAKE_INSTALL_PREFIX@"

--- a/CMake/cdat_modules_extra/setup_runtime.sh.in
+++ b/CMake/cdat_modules_extra/setup_runtime.sh.in
@@ -35,6 +35,10 @@ library_paths=( @SETUP_LIBRARY_PATHS@ )
 python_paths=( @SETUP_PYTHON_PATHS@ )
 executable_paths=( @SETUP_EXECUTABLE_PATHS@ )
 
+if [ -z "$UVCDAT_DISABLE_PROMPT" ] ; then
+    export PS1="(uvcdat)$PS1"
+fi
+
 if [ -d '@QT_LIB_DIR@' ] ; then
   LD_LIBRARY_PATH='@QT_LIB_DIR@:'"${LD_LIBRARY_PATH}"
 fi

--- a/CMake/cdat_modules_extra/uvcdat.in
+++ b/CMake/cdat_modules_extra/uvcdat.in
@@ -3,5 +3,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 INSTALL_PREFIX=`dirname ${DIR}`
 . $DIR/setup_runtime.sh
-python@PYVER@ $INSTALL_PREFIX/vistrails/vistrails/uvcdat.py $@
-
+python@PYVER@ $INSTALL_PREFIX/vistrails/vistrails/uvcdat.py "$@"

--- a/CMake/cdat_modules_extra/uvcdat.in
+++ b/CMake/cdat_modules_extra/uvcdat.in
@@ -1,6 +1,4 @@
 #!/bin/bash
-# source is not portable where as . is
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-INSTALL_PREFIX=`dirname ${DIR}`
-. $DIR/setup_runtime.sh
-python@PYVER@ $INSTALL_PREFIX/vistrails/vistrails/uvcdat.py "$@"
+# source is not portable whereas . is
+. "@CMAKE_INSTALL_PREFIX@/bin/setup_runtime.sh"
+python@PYVER@ "@CMAKE_INSTALL_PREFIX@/vistrails/vistrails/uvcdat.py" "$@"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,6 +698,11 @@ configure_file(${cdat_CMAKE_SOURCE_DIR}/cdat_modules_extra/uvcdat.in
   @ONLY
 )
 
+configure_file(${cdat_CMAKE_SOURCE_DIR}/cdat_modules_extra/cdat.in
+  ${CMAKE_INSTALL_PREFIX}/bin/cdat
+  @ONLY
+)
+
 
 if (BUILD_TESTING)
   configure_file(${cdat_CMAKE_SOURCE_DIR}/cdat_modules_extra/runpytest.in
@@ -706,6 +711,38 @@ if (BUILD_TESTING)
   )
   add_subdirectory(testing)
 endif()
+
+# Where to install the wrapper scripts
+set(WRAPPER_INSTALL_LOCATION ${CMAKE_INSTALL_PREFIX}/wrappers
+    CACHE PATH
+    "Install wrapper scripts 'cdat', 'uvcdat' and 'loadcdat' in that directory")
+
+add_custom_command(
+        OUTPUT ${WRAPPER_INSTALL_LOCATION}/loadcdat
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_INSTALL_PREFIX}/bin/setup_runtime.sh
+        ${WRAPPER_INSTALL_LOCATION}/loadcdat)
+add_custom_command(
+        OUTPUT ${WRAPPER_INSTALL_LOCATION}/loadcdat.csh
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_INSTALL_PREFIX}/bin/setup_runtime.csh
+        ${WRAPPER_INSTALL_LOCATION}/loadcdat.csh)
+add_custom_command(
+        OUTPUT ${WRAPPER_INSTALL_LOCATION}/uvcdat
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_INSTALL_PREFIX}/bin/uvcdat
+        ${WRAPPER_INSTALL_LOCATION}/uvcdat)
+add_custom_command(
+        OUTPUT ${WRAPPER_INSTALL_LOCATION}/cdat
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_INSTALL_PREFIX}/bin/cdat
+        ${WRAPPER_INSTALL_LOCATION}/cdat)
+
+add_custom_target(wrappers ALL DEPENDS
+                  ${WRAPPER_INSTALL_LOCATION}/loadcdat
+                  ${WRAPPER_INSTALL_LOCATION}/loadcdat.csh
+                  ${WRAPPER_INSTALL_LOCATION}/uvcdat
+                  ${WRAPPER_INSTALL_LOCATION}/cdat)
 
 # Package UV-CDAT with CPACK
 include(InstallRequiredSystemLibraries)


### PR DESCRIPTION
Sourcing the setup_environment.sh before using the software is error-prone. Furthermore, it is not actually needed anymore when running 'uvcdat', since the wrapper script will source it; this causes a warning to be displayed (`UVCDAT setup already sourced for this install location.`).

Also, once `setup_runtime.sh` is sourced, a whole bunch of executables appear in the path, replacing the system's default (things like `python`, `curl`, `uuid`... 260 in total on my system). For the same reasons, installing UV-CDAT globally is not a good idea (will break system's `python`).

This pull request intends to make the setup_runtime logic internal, and exposes `uvcdat` and `uvcdatpython` wrappers that can safely be added to the PATH (since they are on a directory of their own).

TODO:
* [X] Change setup_runtime.sh
  * Re-running the script for same installation path is fine
  * However running for a different path fails
  * Remove shebang, should only be sourced
* [X] Create wrappers
  * Scripts that set the environment then run their conterpart
  * 'cdat' (python), 'uvcdat' (vistrails), 'activate_uvcdat' (setup_runtime.sh')
  * They get the path from @-variables, not their location; they can be installed out of the install tree (e.g. somewhere on the user's PATH)
  * [ ] uvcdat.mac.in wasn't updated, I don't know what that is
* [X] Get CMake to configure and install wrappers
  * [X] They get copied at build time or with `make wrappers` (if you need to do it as root)
  * [X] Location configured by `WRAPPER_INSTALL_LOCATION` cache variable, defaults to `${CMAKE_INSTALL_PREFIX}/wrappers` (not so useful but you can manually add on PATH)
  * `make install` cannot be used, it is broken because of its special use in CPack
* [ ] Review and test
  * I'd definitely like some feedback on this
* [ ] Update setup_runtime.csh
  * I don't know much about csh, need help