### PR TITLE
Hook up anim recording to QT anim stepper

### DIFF
--- a/Packages/DV3D/DV3DPlot.py
+++ b/Packages/DV3D/DV3DPlot.py
@@ -296,8 +296,8 @@ class DV3DPlot():
         sys.exit( 0 )
 
     def stepAnimation(self, **args): 
-        pass
-    
+        if self.record_animation: self.captureFrame()
+   
     def stepAnimationSignal(self):
         self.renderWindowInteractor.SetTimerEventId( self.AnimationExternalEventId )
         self.renderWindowInteractor.SetTimerEventType( self.AnimationTimerType )
@@ -332,7 +332,6 @@ class DV3DPlot():
         self.renderWindowInteractor.SetTimerEventId( self.AnimationEventId )
         self.renderWindowInteractor.SetTimerEventType( self.AnimationTimerType )
         self.animationTimerId = self.renderWindowInteractor.CreateOneShotTimer( event_duration )
-        if self.record_animation: self.captureFrame()
         
     def captureFrame( self, **args ):   
         frameCaptureFilter = vtk.vtkWindowToImageFilter()

--- a/Packages/DV3D/PointCloudViewer.py
+++ b/Packages/DV3D/PointCloudViewer.py
@@ -442,6 +442,7 @@ class CPCPlot( DV3DPlot ):
         self.setRenderMode( ProcessMode.LowRes )   
         self.point_cloud_overview.stepTime( process=True, update_points=thresholding)
         self.low_res_actor.VisibilityOn()                                    
+        DV3DPlot.stepAnimation(self, **args)
         self.render() 
 
     def update_subset_specs(self, new_specs ):

--- a/Packages/DV3D/StructuredGridPlot.py
+++ b/Packages/DV3D/StructuredGridPlot.py
@@ -648,6 +648,7 @@ class StructuredGridPlot(DV3DPlot):
         self.execute( )
         if timestamp:   self.updateTextDisplay( "Timestep: %s" % str( timestamp ) )
         else:           self.updateTextDisplay( "" )
+        DV3DPlot.stepAnimation(self, **args)
 
     def onResizeEvent(self):
         self.updateTextDisplay( None, True )


### PR DESCRIPTION
Fixes animation recoding in GUI which was not working because the recording was implemented in the VTK animation stepper and the gui is using a different (Qt based) animation stepper.
