### PR TITLE
Moved CMOR tarball

### DIFF
--- a/CMake/cdat_modules/cmor_pkg.cmake
+++ b/CMake/cdat_modules/cmor_pkg.cmake
@@ -1,5 +1,5 @@
 set(CMOR_VERSION 2.9.2)
-set(CMOR_URL https://github.com/PCMDI/cmor/archive)
+set(CMOR_URL ${LLNL_URL})
 set(CMOR_GZ CMOR-${CMOR_VERSION}.tar.gz)
 set(CMOR_MD5 f7e78104878d93ffbd3cae2ccd95db2c)
 set (nm CMOR)


### PR DESCRIPTION
Because we build curl w/o SSL on RH6/CentOS6 it can't download from gituhb
https, moving CMOR tarball to LLNL server
