### PR TITLE
Enable ParaView's FFMPEG support in CDAT_BUILD_MODE=ALL builds.

### DIFF
--- a/CMake/cdat_modules/paraview_deps.cmake
+++ b/CMake/cdat_modules/paraview_deps.cmake
@@ -8,3 +8,6 @@ if(CDAT_BUILD_PARALLEL)
   list(APPEND ParaView_deps "${mpi_pkg}")
 endif()
 
+if(NOT CDAT_BUILD_LEAN)
+  list(APPEND ParaView_deps "${ffmpeg_pkg}")
+endif()

--- a/CMake/cdat_modules/paraview_external.cmake
+++ b/CMake/cdat_modules/paraview_external.cmake
@@ -27,6 +27,9 @@ list(APPEND ParaView_tpl_args
   -DModule_vtkIOCGM:BOOL=ON
   )
 
+if(NOT CDAT_BUILD_LEAN)
+  list(APPEND ParaView_tpl_args -DPARAVIEW_ENABLE_FFMPEG:BOOL=ON)
+endif()
 
 if (CDAT_BUILD_PARALLEL)
   list(APPEND ParaView_tpl_args


### PR DESCRIPTION
Ref #799.
