### PR TITLE
Makes git_update.sh handle detached heads

### DIFF
--- a/CMake/cdat_modules_extra/git_update.sh.in
+++ b/CMake/cdat_modules_extra/git_update.sh.in
@@ -2,7 +2,7 @@
 cd @SOURCE_DIR@
 git fetch origin --prune
 branch_name=$(git symbolic-ref HEAD | sed -e 's,.*\/\(.*\),\1,')
-if [ "${branch_name}" != "@BRANCH@" ]; then
+if [ $? = 0 -a "${branch_name}" != "@BRANCH@" ]; then
   git checkout -f @BRANCH@
 fi
 git reset --hard origin/@BRANCH@


### PR DESCRIPTION
`git symbolic-ref HEAD` will fail in detached head mode.
