### PR TITLE
Changes VisTrails URL to Github

### DIFF
--- a/CMake/cdat_modules/vistrails_pkg.cmake
+++ b/CMake/cdat_modules/vistrails_pkg.cmake
@@ -1,5 +1,5 @@
 set(VISTRAILS_VERSION ${VISTRAILS_TAG_POINT})
-set(VISTRAILS_SOURCE "${GIT_PROTOCOL}vistrails.org/git/vistrails.git")
+set(VISTRAILS_SOURCE "${GIT_PROTOCOL}github.com/UV-CDAT/VisTrails.git")
 set(VISTRAILS_VERSION uvcdat-master)
 ## Now tarball so faking md5 to tell checkout point
 set(VISTRAILS_MD5 uvcdat-master)


### PR DESCRIPTION
As indicated by my email on Oct 15, I think UV-CDAT should really be using a [Github fork of VisTrails](/UV-CDAT/VisTrails) to host the VisTrails repository and all the branches. That would allow us developers to use pull requests the way we do for changes on the main UV-CDAT repository (this one, UV-CDAT/uvcdat) and uvcdat-testdata, instead of pushing to vistrails.org and commenting with a branch name.

I am unaware of further discussion on this (didn't see anything on Github or the mailing-list), feel free to comment.

A nightly script updates [the fork](/UV-CDAT/VisTrails) from vistrails.org right now, we can make it do the contrary when you decide to switch.
