### PR TITLE
Clones to 'vistrails' no matter the URL

### DIFF
--- a/CMake/cdat_modules/vistrails_external.cmake
+++ b/CMake/cdat_modules/vistrails_external.cmake
@@ -52,6 +52,7 @@ endif()
 set(SOURCE_DIR "${CMAKE_INSTALL_PREFIX}/vistrails")
 set(BRANCH ${VISTRAILS_TAG_POINT})
 set(GIT_URL "${vistrails_url}")
+set(GIT_TARGET "vistrails")
 
 option(CDAT_DELETE_VISTRAILS_HISTORY "Delete GIT history of vistrails" OFF)
 option(CDAT_AUTO_UPDATE_VISTRAILS_TAG_POINT "Delete GIT history of vistrails" ON)

--- a/CMake/cdat_modules_extra/git_clone.sh.in
+++ b/CMake/cdat_modules_extra/git_clone.sh.in
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 cd @CMAKE_INSTALL_PREFIX@
-@GIT_EXECUTABLE@ clone --depth 1 -b @BRANCH@  @GIT_URL@
-
+@GIT_EXECUTABLE@ clone --depth 1 -b @BRANCH@ @GIT_URL@ @GIT_TARGET@


### PR DESCRIPTION
Currently, the git_clone.sh.in script lets Git clone to whatever directory name it makes up from the URL. This changes it to an explicit destination.

IMHO there is no point in using a separate sh script configured by CMake for that (the script contains a single command!)

Fixes #894, replaces #895
