### PR TITLE
Removed references to textcombined.colormap

### DIFF
--- a/Packages/vcs/Lib/textcombined.py
+++ b/Packages/vcs/Lib/textcombined.py
@@ -561,7 +561,6 @@ class Tc(object):
         print "path =", self.path
         print "halign =", self.halign
         print "valign =", self.valign
-        print "colormap =", self.colormap
 
     #############################################################################
     #                                                                           #
@@ -658,7 +657,6 @@ class Tc(object):
            fp.write("%s.path = '%s'\n" % (unique_name, self.path))
            fp.write("%s.halign = '%s'\n" % (unique_name, self.halign))
            fp.write("%s.valign = '%s'\n\n" % (unique_name, self.valign))
-           fp.write("%s.colormap = '%s'\n\n" % (unique_name, repr(self.colormap)))
            fp.close()
         else:
           #Json type


### PR DESCRIPTION
There doesn't appear to be any colormap attribute on `textcombined`, but in `textcombined.script()` and `textcombined.list()`, it was used.  This would raise an `AttributeError` when writing a python script or listing attribute values.  I removed the references in both functions.