### PR TITLE
Star and triangle fix

### DIFF
--- a/Packages/vcs/Lib/vcs2vtk.py
+++ b/Packages/vcs/Lib/vcs2vtk.py
@@ -1088,6 +1088,9 @@ def prepMarker(renWin,marker,cmap=None):
       apd.AddInputData(pd)
       apd.Update()
       g.SetSourceData(apd.GetOutput())
+    elif t[:4] == "star":
+      pd = starPolyData()
+      g.SetSourceData(pd)
     elif t in ["w%.2i" % x for x in range(203)]:
       ## WMO marker
       params = wmo[t]
@@ -1254,3 +1257,70 @@ def checkProjParameters(self,name,value):
   return value
 def getProjType(value):
   return vtkProjections[value-200]
+
+# Used for the star marker
+def starPolyData():
+  """Creates poly data for a star"""
+  points = starPoints(.01, 0, 0)
+  pts = vtk.vtkPoints()
+  for ind, point in enumerate(points):
+    pts.InsertPoint(ind, (point[0], point[1], 0))
+  pts.InsertPoint(ind + 1, (0, 0, 0))
+
+  polys = vtk.vtkCellArray()
+  # Outer triangles
+  for i in range(0, 10, 2):
+    id_list = vtk.vtkIdList()
+    id_list.InsertNextId(i)
+    id_list.InsertNextId((i + 1) % 10)
+    id_list.InsertNextId((i - 1) % 10)
+    polys.InsertNextCell(id_list)
+
+  # Inner triangles
+  point_indices = [
+      (1, 10, 9),
+      (3, 10, 1),
+      (5, 10, 3),
+      (7, 10, 5),
+      (9, 10, 7)
+  ]
+
+  for group in point_indices:
+    id_list = vtk.vtkIdList()
+    for index in group:
+      id_list.InsertNextId(index)
+    polys.InsertNextCell(id_list)
+
+  pd = vtk.vtkPolyData()
+  pd.SetPoints(pts)
+  pd.SetPolys(polys)
+
+  return pd
+
+def starPoints(radius_outer, x, y, number_points = 5):
+  """Defines coordinate points for an arbitrary star"""
+  from math import sin, cos
+  # Point at the top of the star
+  theta = numpy.pi / 2.0
+
+  # Angular distance from one point to the next
+  delta_theta = 2 * numpy.pi / float(number_points)
+
+  # Size of the interior circle
+  radius_inner = radius_outer / 2.0
+
+  points = []
+  for point_index in range(number_points * 2):
+    # Outer point
+    dx = radius_outer * cos(theta)
+    dy = radius_outer * sin(theta)
+
+    points.append((x + dx, y + dy))
+
+    # Inner point
+    dx = radius_inner * cos(theta + delta_theta / 2.0)
+    dy = radius_inner * sin(theta + delta_theta / 2.0)
+    points.append((x + dx, y + dy))
+
+    theta += delta_theta
+  return points

--- a/Packages/vcs/Lib/vcs2vtk.py
+++ b/Packages/vcs/Lib/vcs2vtk.py
@@ -1031,6 +1031,7 @@ def prepMarker(renWin,marker,cmap=None):
       gs.FilledOff()
     elif t[:8]=='triangle':
       gs.SetGlyphTypeToTriangle()
+      gs.FilledOff()
       if t[9]=="d":
         gs.SetRotationAngle(180)
       elif t[9]=="l":

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -194,6 +194,11 @@ add_test(vcs_test_taylor_2_quads
     ${cdat_SOURCE_DIR}/testing/vcs/test_markers.py
     "${BASELINE_DIR}/test_markers.png"
     )
+  add_test(vcs_test_star_triangle_markers
+    ${CMAKE_INSTALL_PREFIX}/bin/python
+    ${cdat_SOURCE_DIR}/testing/vcs/test_star_triangle_markers.py
+    "${BASELINE_DIR}/test_star_triangle_markers.png"
+    )
   add_test(vcs_test_boxfill_10x10_numpy
     ${CMAKE_INSTALL_PREFIX}/bin/python
     ${cdat_SOURCE_DIR}/testing/vcs/test_boxfill_10x10_numpy.py

--- a/testing/vcs/test_star_triangle_markers.py
+++ b/testing/vcs/test_star_triangle_markers.py
@@ -1,0 +1,27 @@
+
+import vcs,numpy,cdms2,MV2,os,sys
+src=sys.argv[1]
+pth = os.path.join(os.path.dirname(__file__),"..")
+sys.path.append(pth)
+import checkimage
+
+x=vcs.init()
+x.drawlogooff()
+x.setbgoutputdimensions(1200,1091,units="pixels")
+
+m = x.createmarker()
+
+m.type = ["star", "triangle_right", "triangle_left", "triangle_up", "triangle_down"]
+m.x = [[.1], [.3], [.5], [.7], [.9]]
+m.y = [[.1], [.3], [.5], [.7], [.9]]
+m.color = [200, 150, 160, 175, 125]
+m.size = [50, 50, 50, 50, 50]
+x.plot(m,bg=1)
+fnm = "test_star_triangle_markers.png"
+x.png(fnm)
+
+print "fnm:",fnm
+print "src:",src
+
+ret = checkimage.check_result_image(fnm,src,checkimage.defaultThreshold)
+sys.exit(ret)


### PR DESCRIPTION
Star and triangle markers are both broken in current master branch.

Star markers, despite passing validation as a real marker type in VCS_validation_functions.checkMarker, generate these error messages when plotting:

```
$ python marker.py 
/path/to/uvcdat/python2.7/site-packages/vcs/vcs2vtk.py:1113: UserWarning: unknown marker type: star, using dot
  warnings.warn("unknown marker type: %s, using dot" % t)
/path/to/uvcdat/python2.7/site-packages/vcs/VTKPlots.py:80: UserWarning: Press 'Q' to exit interactive mode and continue script execution
  warnings.warn("Press 'Q' to exit interactive mode and continue script execution")
```

where marker.py looks like this:

```
import vcs

canvas = vcs.init()

m = canvas.createmarker("markers")

m.x = [.5]
m.y = [.5]
m.type = "star"
m.size = 50
m.color = 1
m.priority = 3

canvas.plot(m)
canvas.interact()
```

and generates this image:
![screen shot 2015-01-09 at 12 23 25 pm](https://cloud.githubusercontent.com/assets/718512/5686729/88b36b12-97fa-11e4-90af-b363a151dd14.png)

I added star to vcs2vtk (1091:1120 and 1287:1313), so with my patch we'll get this:

![screen shot 2015-01-09 at 12 23 11 pm](https://cloud.githubusercontent.com/assets/718512/5686730/8b63f1ba-97fa-11e4-9574-04b28275d6ec.png)

Marker types triangle_left, triangle_right, triangle_up, and triangle_down are currently displaying filled, despite the existence of triangle_left_fill, et. al.
For the script:

```
import vcs

canvas = vcs.init()

m = canvas.createmarker("markers")

m.x = [[.2], [.3], [.4], [.5]]
m.y = [[.5], [.5], [.5], [.5]]
m.type = ["triangle_left", "triangle_up", "triangle_right", "triangle_down"]
m.size = 100
m.color = 1
m.priority = 3

canvas.plot(m)
canvas.interact()
```

we get the image 

![screen shot 2015-01-09 at 11 40 57 am](https://cloud.githubusercontent.com/assets/718512/5686029/7d01a8de-97f4-11e4-9423-32bd05d650f2.png)

With a one-line fix (adding `gs.FilledOff()` at line 1034), we now get this:
![screen shot 2015-01-09 at 11 42 27 am](https://cloud.githubusercontent.com/assets/718512/5686764/d74adfee-97fa-11e4-8475-f06b17d3cc8e.png)

