### PR TITLE
Fixes exception from VTKVCSBackend

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -54,6 +54,7 @@ class VTKVCSBackend(object):
 
     if sys.platform == "darwin":
         self.reRender = False
+    self.clickRenderer = None
 
   def setAnimationStepper( self, stepper ):
       for plot in self.plotApps.values():
@@ -172,9 +173,10 @@ class VTKVCSBackend(object):
     self.renWin.Render()
 
   def leftButtonReleaseEvent(self,obj,event):
-    self.clickRenderer.RemoveAllViewProps()
-    self.renWin.RemoveRenderer(self.clickRenderer)
-    self.renWin.Render()
+    if self.clickRenderer is not None:
+      self.clickRenderer.RemoveAllViewProps()
+      self.renWin.RemoveRenderer(self.clickRenderer)
+      self.renWin.Render()
 
   def configureEvent(self,obj,ev):
     sz = self.renWin.GetSize()


### PR DESCRIPTION
Attributes should always be initialized in `__init__`.

This fixes the rare case of `leftButtonReleaseEvent()` happening before any `leftButtonPressEvent()`.