### PR TITLE
Line duplicate points fix

### DIFF
--- a/Packages/vcs/Lib/vcs2vtk.py
+++ b/Packages/vcs/Lib/vcs2vtk.py
@@ -1182,29 +1182,38 @@ def prepMarker(renWin,marker,cmap=None):
   return actors
 
 def prepLine(renWin,line,cmap=None):
-  n = prepPrimitive(line)
-  if n==0:
+  number_lines = prepPrimitive(line)
+
+  if number_lines == 0:
     return
+
   actors = []
-  for i in range(n):
+
+  for i in range(number_lines):
     l = vtk.vtkLine()
     lines = vtk.vtkCellArray()
     x = line.x[i]
-    y=line.y[i]
-    c=line.color[i]
-    w=line.width[i]
-    t=line.type[i]
-    N = max(len(x),len(y))
+    y = line.y[i]
+    c = line.color[i]
+    w = line.width[i]
+    t = line.type[i]
+    number_points = max(len(x),len(y))
+
+    # Extend x or y to the length of the other by duplicating the last coord.
     for a in [x,y]:
-      while len(a)<n:
+      while len(a)<number_points:
         a.append(a[-1])
+
     pts = vtk.vtkPoints()
-    for j in range(N):
+
+    for j in range(number_points):
       pts.InsertNextPoint(x[j],y[j],0.)
-    for j in range(N-1):
+
+    for j in range(number_points - 1):
       l.GetPointIds().SetId(0,j)
       l.GetPointIds().SetId(1,j+1)
       lines.InsertNextCell(l)
+
     linesPoly = vtk.vtkPolyData()
     geo,pts=project(pts,line.projection,line.worldcoordinate)
     linesPoly.SetPoints(pts)

--- a/testing/vcs/test_vcs_line_point_extension.py
+++ b/testing/vcs/test_vcs_line_point_extension.py
@@ -1,0 +1,21 @@
+import vcs, os, sys
+
+x = vcs.init()
+line = x.createline()
+line.x = [[0, .1], [.2, .3], [.4, .5], [.6, .7]]
+line.y = [[0, .1], [.2, .3, .4], [.5], [.6, .7]]
+x.plot(line)
+
+if line.x[0] != [0, .1]:
+  print "line.x[0] should be [0, .1]; is %s" % line.x[0]
+  sys.exit(-1)
+
+if line.x[1] != [.2, .3, .3]:
+  print 'line.x[1] should be [.2, .3]; is %s' % line.x[1]
+  sys.exit(-1)
+
+if line.y[2] != [.5, .5]:
+  print "line.y[2] should be [.5, .5]; is %s" % line.y[2]
+  sys.exit(-1)
+
+sys.exit(0)

--- a/testing/vcs/test_vcs_line_point_extension.py
+++ b/testing/vcs/test_vcs_line_point_extension.py
@@ -13,7 +13,7 @@ if line.x[0] != [0, .1]:
   sys.exit(-1)
 
 if line.x[1] != [.2, .3, .3]:
-  print 'line.x[1] should be [.2, .3]; is %s' % line.x[1]
+  print 'line.x[1] should be [.2, .3, .3]; is %s' % line.x[1]
   sys.exit(-1)
 
 if line.y[2] != [.5, .5]:

--- a/testing/vcs/test_vcs_line_point_extension.py
+++ b/testing/vcs/test_vcs_line_point_extension.py
@@ -1,10 +1,12 @@
 import vcs, os, sys
 
 x = vcs.init()
+
 line = x.createline()
 line.x = [[0, .1], [.2, .3], [.4, .5], [.6, .7]]
 line.y = [[0, .1], [.2, .3, .4], [.5], [.6, .7]]
-x.plot(line)
+
+x.plot(line, bg=1)
 
 if line.x[0] != [0, .1]:
   print "line.x[0] should be [0, .1]; is %s" % line.x[0]


### PR DESCRIPTION
When using lines in vcs, a bug would add many duplicate points to the line object. Here's a sample:

```python
import vcs

x = vcs.init()

l = x.createline()

l.x = [[0, .5], [0, .75], [0, 1]]
l.y = [[0, .5], [0, .75], [0, 1]]

print l.x
print l.y

x.plot(l, bg=1)

print l.x
print l.y
```

which outputs

```
[[0, 0.5], [0, 0.75], [0, 1]]
[[0, 0.5], [0, 0.75], [0, 1]]
[[0, 0.5, 0.5], [0, 0.75, 0.75], [0, 1, 1]]
[[0, 0.5, 0.5], [0, 0.75, 0.75], [0, 1, 1]]
```

I spruced up the prepLine function in vcs2vtk.py, and renamed the ambiguous variables that led to the bug. I also added a test that makes sure that the X and Y points are being extended correctly.