### PR TITLE
Fix git clone & update helper scripts

### DIFF
--- a/CMake/cdat_modules_extra/git_clone.sh.in
+++ b/CMake/cdat_modules_extra/git_clone.sh.in
@@ -2,4 +2,9 @@
 
 cd "@CMAKE_INSTALL_PREFIX@"
 "@GIT_EXECUTABLE@" clone --no-checkout --depth 1 -b @BRANCH@ @GIT_URL@ "@GIT_TARGET@"
-"@GIT_EXECUTABLE@" checkout origin/@BRANCH@
+cd "@GIT_TARGET@"
+if [ "$("@GIT_EXECUTABLE@" cat-file -t @BRANCH@)" = tag ]; then
+    "@GIT_EXECUTABLE@" checkout @BRANCH@
+else
+    "@GIT_EXECUTABLE@" checkout origin/@BRANCH@
+fi

--- a/CMake/cdat_modules_extra/git_clone.sh.in
+++ b/CMake/cdat_modules_extra/git_clone.sh.in
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 cd "@CMAKE_INSTALL_PREFIX@"
-"@GIT_EXECUTABLE@" clone --depth 1 -b @BRANCH@ @GIT_URL@ "@GIT_TARGET@"
+"@GIT_EXECUTABLE@" clone --no-checkout --depth 1 -b @BRANCH@ @GIT_URL@ "@GIT_TARGET@"
+"@GIT_EXECUTABLE@" checkout origin/@BRANCH@

--- a/CMake/cdat_modules_extra/git_clone.sh.in
+++ b/CMake/cdat_modules_extra/git_clone.sh.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cd @CMAKE_INSTALL_PREFIX@
-"@GIT_EXECUTABLE@" clone --depth 1 -b @BRANCH@ @GIT_URL@ @GIT_TARGET@
+cd "@CMAKE_INSTALL_PREFIX@"
+"@GIT_EXECUTABLE@" clone --depth 1 -b @BRANCH@ @GIT_URL@ "@GIT_TARGET@"

--- a/CMake/cdat_modules_extra/git_update.sh.in
+++ b/CMake/cdat_modules_extra/git_update.sh.in
@@ -1,8 +1,4 @@
 #!/bin/sh
 cd "@SOURCE_DIR@"
 "@GIT_EXECUTABLE@" fetch origin --prune
-branch_name=$("@GIT_EXECUTABLE@" symbolic-ref HEAD | sed -e 's,.*\/\(.*\),\1,')
-if [ $? = 0 -a "${branch_name}" != "@BRANCH@" ]; then
-  "@GIT_EXECUTABLE@" checkout -f @BRANCH@
-fi
-"@GIT_EXECUTABLE@" reset --hard origin/@BRANCH@
+"@GIT_EXECUTABLE@" checkout -f origin/@BRANCH@

--- a/CMake/cdat_modules_extra/git_update.sh.in
+++ b/CMake/cdat_modules_extra/git_update.sh.in
@@ -1,4 +1,8 @@
 #!/bin/sh
 cd "@SOURCE_DIR@"
 "@GIT_EXECUTABLE@" fetch origin --prune
-"@GIT_EXECUTABLE@" checkout -f origin/@BRANCH@
+if [ "$("@GIT_EXECUTABLE@" cat-file -t @BRANCH@)" = tag ]; then
+    "@GIT_EXECUTABLE@" checkout -f @BRANCH@
+else
+    "@GIT_EXECUTABLE@" checkout -f origin/@BRANCH@
+fi

--- a/CMake/cdat_modules_extra/git_update.sh.in
+++ b/CMake/cdat_modules_extra/git_update.sh.in
@@ -1,9 +1,8 @@
 #!/bin/sh
-cd @SOURCE_DIR@
-git fetch origin --prune
-branch_name=$(git symbolic-ref HEAD | sed -e 's,.*\/\(.*\),\1,')
+cd "@SOURCE_DIR@"
+"@GIT_EXECUTABLE@" fetch origin --prune
+branch_name=$("@GIT_EXECUTABLE@" symbolic-ref HEAD | sed -e 's,.*\/\(.*\),\1,')
 if [ $? = 0 -a "${branch_name}" != "@BRANCH@" ]; then
-  git checkout -f @BRANCH@
+  "@GIT_EXECUTABLE@" checkout -f @BRANCH@
 fi
-git reset --hard origin/@BRANCH@
-
+"@GIT_EXECUTABLE@" reset --hard origin/@BRANCH@


### PR DESCRIPTION
Creating local branches is a bit weird, and moving them is definitely not a good idea.

This places Git in "detached head" mode without creating or changing local branches. Remember that BRANCH might very well be a tag name.