### PR TITLE
Need to escape an additional % in install.py

### DIFF
--- a/CMake/cdat_modules_extra/install.py.in
+++ b/CMake/cdat_modules_extra/install.py.in
@@ -268,7 +268,7 @@ def get_prefix():
     if os.uname()[0] == "Darwin":
       uv_setup_pth = os.path.join(uv_setup_pth,
           "Library","Frameworks","Python.framework","Versions",
-          "%%i.%%i" % (sys.version_info.major,sys.version_info.minor)
+          "%%i.%%i" %% (sys.version_info.major,sys.version_info.minor)
           )
     return uv_setup_pth
   except KeyError:


### PR DESCRIPTION
This [commit](https://github.com/UV-CDAT/uvcdat/commit/4bc10968e29742f0714dff26971c893713fe5fa8#diff-364b4e9b07d47ae67379edb8858a5b19) missed a `%` that needs to be escaped resulting in the error mentioned [here](https://github.com/UV-CDAT/uvcdat/issues/991#issuecomment-72233051).  I'm still building locally, so I can't yet verify if this works.