### PR TITLE
Export text as paths in vector exports.

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1338,6 +1338,7 @@ class VTKVCSBackend(object):
     gl.SetInput(self.renWin)
     gl.SetCompress(0) # Do not compress
     gl.SetFilePrefix(".".join(file.split(".")[:-1]))
+    gl.TextAsPathOn()
     if output_type=="svg":
         gl.SetFileFormatToSVG()
     elif output_type == "ps":


### PR DESCRIPTION
The text alignment flags aren't handled consistently across GL2PS
backends (e.g. PDF has no concept of alignment), so exporting the text
as a series of Bezier curves will ensure that the resulting export is
consistent, regardless of format and/or viewer.

This fixes #503. Note that I had to fix an issue with VTK for this to handle the custom fonts properly -- make sure UV-CDAT/VTK@9760973f6acbfc64a3a29ffecda30ebd6675310a is in your VTK tree when testing (VTK/uvcdat-master has already been updated).