### PR TITLE
Update background color

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -228,6 +228,10 @@ class VTKVCSBackend(object):
             ren.RemoveAllViewProps()
             if not ren.GetLayer()==0:
               self.renWin.RemoveRenderer(ren)
+            else:
+              #Update background color
+              r,g,b = [c / 255. for c in self.canvas.backgroundcolor]
+              ren.SetBackground(r,g,b)
         ren = renderers.GetNextItem()
     if hasValidRenderer and self.renWin.IsDrawable():
         self.renWin.Render()

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -199,6 +199,16 @@ add_test(vcs_test_taylor_2_quads
     ${cdat_SOURCE_DIR}/testing/vcs/test_star_triangle_markers.py
     "${BASELINE_DIR}/test_star_triangle_markers.png"
     )
+  add_test(vcs_test_canvas_background
+    "${PYTHON_EXECUTABLE}"
+    ${cdat_SOURCE_DIR}/testing/vcs/test_canvas_background.py
+    "${BASELINE_DIR}/test_canvas_background.png"
+    )
+  add_test(vcs_test_canvas_background_update
+    "${PYTHON_EXECUTABLE}"
+    ${cdat_SOURCE_DIR}/testing/vcs/test_canvas_background_update.py
+    "${BASELINE_DIR}/test_canvas_background_update.png"
+    )
   add_test(vcs_test_boxfill_10x10_numpy
     "${PYTHON_EXECUTABLE}"
     ${cdat_SOURCE_DIR}/testing/vcs/test_boxfill_10x10_numpy.py

--- a/testing/vcs/test_vcs_canvas_background.py
+++ b/testing/vcs/test_vcs_canvas_background.py
@@ -1,0 +1,20 @@
+import vcs, cdms2, os, sys
+
+pth = os.path.join(os.path.dirname(__file__),"..")
+sys.path.append(pth)
+import checkimage
+
+x = vcs.init()
+
+x.drawlogooff()
+x.setbgoutputdimensions(500,500, units="pixels")
+
+x.backgroundcolor = (255, 255, 255)
+x.open()
+fnm = "test_backgroundcolor_white.png"
+x.png(fnm)
+
+src=sys.argv[1]
+ret = checkimage.check_result_image(fnm, src, checkimage.defaultThreshold)
+
+sys.exit(ret)

--- a/testing/vcs/test_vcs_canvas_background_update.py
+++ b/testing/vcs/test_vcs_canvas_background_update.py
@@ -1,0 +1,22 @@
+import vcs, cdms2, os, sys
+
+pth = os.path.join(os.path.dirname(__file__),"..")
+sys.path.append(pth)
+import checkimage
+
+x = vcs.init()
+
+x.drawlogooff()
+x.setbgoutputdimensions(500,500, units="pixels")
+
+x.backgroundcolor = (255, 255, 255)
+x.open()
+x.backgroundcolor = (255, 255, 0)
+x.update()
+fnm = "test_backgroundcolor_yellow.png"
+x.png(fnm)
+
+src=sys.argv[1]
+ret = checkimage.check_result_image(fnm, src, checkimage.defaultThreshold)
+
+sys.exit(ret)


### PR DESCRIPTION
If you update canvas.backgroundcolor after rendering and do canvas.update(), the canvas' background color does not update. Added tests for that, and fixed the bug. I'm up for moving the fix to a different place, but the backend.clear() function was the most convenient location (since there was already an if statement that separated out the specific renderer I was looking to update, and gets called during every update()). Incoming PR for uvcdat-testdata to provide the images as well.