### PR TITLE
Increase the initial GL2PS feedback buffer size.

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1340,7 +1340,12 @@ class VTKVCSBackend(object):
     # vertices produced by OpenGL. If you start seeing a lot of warnings:
     # GL2PS info: OpenGL feedback buffer overflow
     # increase it to save some time.
-    gl.SetBufferSize(50*1024*1024) # 50MB
+    # ParaView lags so we need a try/except around this
+    # in case it is a ParaView build
+    try:
+      gl.SetBufferSize(50*1024*1024) # 50MB
+    except:
+      pass
 
     # Since the vcs layer stacks renderers to manually order primitives, sorting
     # is not needed and will only slow things down and introduce artifacts.

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1342,6 +1342,10 @@ class VTKVCSBackend(object):
     # increase it to save some time.
     gl.SetBufferSize(50*1024*1024) # 50MB
 
+    # Since the vcs layer stacks renderers to manually order primitives, sorting
+    # is not needed and will only slow things down and introduce artifacts.
+    gl.SetSortToOff()
+
     gl.SetInput(self.renWin)
     gl.SetCompress(0) # Do not compress
     gl.SetFilePrefix(".".join(file.split(".")[:-1]))

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1335,6 +1335,13 @@ class VTKVCSBackend(object):
       raise Exception("Nothing on Canvas to dump to file")
 
     gl  = vtk.vtkGL2PSExporter()
+
+    # This is the size of the initial memory buffer that holds the transformed
+    # vertices produced by OpenGL. If you start seeing a lot of warnings:
+    # GL2PS info: OpenGL feedback buffer overflow
+    # increase it to save some time.
+    gl.SetBufferSize(50*1024*1024) # 50MB
+
     gl.SetInput(self.renWin)
     gl.SetCompress(0) # Do not compress
     gl.SetFilePrefix(".".join(file.split(".")[:-1]))


### PR DESCRIPTION
To prevent having to resize and rerender multiple times when a very large
amount of data is pushed through (see #517), start with a 50MB buffer.

This buffer size is sufficient to store the 1M triangles used in the #517
example.

@doutriaux1 @aashish24 