### PR TITLE
fix #118

### DIFF
--- a/Packages/cdms2/Lib/avariable.py
+++ b/Packages/cdms2/Lib/avariable.py
@@ -993,6 +993,10 @@ class AbstractVariable(CdmsObj, Slab):
             if fromgrid.getBounds() is not None and hasattr(regrid2,"ESMFRegrid"):
                 regridTool = 'esmf'
                 regridMethod = 'linear'
+                # Hum ok if only 1 longitude regrid fails, let's check
+                if len(togrid.getLongitude())==1:
+                  # esmf can't deal with this
+                  regridTool   = "regrid2"
 
             # let user override
             userSpecifiesMethod = False

--- a/testing/cdms2/CMakeLists.txt
+++ b/testing/cdms2/CMakeLists.txt
@@ -9,6 +9,10 @@ add_test("test_dim_unlimited"
     "${PYTHON_EXECUTABLE}"
     ${cdat_SOURCE_DIR}/testing/cdms2/test_dim_unlimited.py
     TestCDATLite)
+  add_test("CDMS_Test_Zonal_regrid_Switch_to_Regrid2"
+    "${PYTHON_EXECUTABLE}"
+    ${cdat_SOURCE_DIR}/testing/cdms2/test_regrid_zonal_switch_to_regrid2.py)
+
 add_test("CDMS_Test_01"
     "${PYTHON_EXECUTABLE}"
     ${cdat_SOURCE_DIR}/testing/cdms2/cdtest01.py)

--- a/testing/cdms2/test_regrid_zonal_switch_to_regrid2.py
+++ b/testing/cdms2/test_regrid_zonal_switch_to_regrid2.py
@@ -1,0 +1,10 @@
+import cdms2
+import os,sys
+
+f=cdms2.open(os.path.join(sys.prefix,"sample_data","clt.nc"))
+
+s=f("clt",slice(0,1))
+
+g=cdms2.createGaussianGrid(64)
+gl = cdms2.createZonalGrid(g)
+regridded = s.regrid(gl)


### PR DESCRIPTION
when using zonal grid as target switch to regrid2 for regrodTool as esmf seg faults