### PR TITLE
Workaround for #1093

### DIFF
--- a/Packages/vcs/Lib/editors/font.py
+++ b/Packages/vcs/Lib/editors/font.py
@@ -1,0 +1,16 @@
+import vcs
+
+class FontEditor(object):
+    def __init__(self, toolbar, font_setter, current_font="default"):
+
+        self.toolbar = toolbar
+        self.set_font = font_setter
+
+        self.fonts = sorted(vcs.elements["font"].keys())
+
+        self.font_button = self.toolbar.add_button(self.fonts, action=self.font_state)
+        self.font_button.set_state(self.fonts.index(current_font))
+
+    def font_state(self, state):
+        font = self.fonts[state]
+        self.set_font(font)

--- a/Packages/vcs/Lib/editors/label.py
+++ b/Packages/vcs/Lib/editors/label.py
@@ -3,7 +3,7 @@ import vcs
 import text
 #import vtk
 import vcs.vcs2vtk
-from functools import partial
+from font import FontEditor
 
 __valign_map__ = {
     0: 0,
@@ -63,27 +63,8 @@ class LabelEditor(point.PointEditor):
         valign.set_state(__valign_map__[self.to.valign])
 
         self.angle_button = self.toolbar.add_slider_button(self.to.angle, 0, 360, "Angle", update=self.update_angle)
-        self.fonts = sorted(vcs.elements["font"].keys())
 
-        font_toolbar = self.toolbar.add_toolbar("Fonts")
-
-        self.font_buttons = {}
-
-        def font_setter(font):
-            return partial(self.set_font, font)
-
-        deactivate = font_setter("default")
-
-        for ind, font in enumerate(self.fonts):
-
-            if font[:4] != "Math":
-                button = font_toolbar.add_toggle_button(font, on=font_setter(font), off=deactivate, font=vcs.elements["font"][font])
-            else:
-                button = font_toolbar.add_toggle_button(font, on=font_setter(font), off=deactivate)
-
-            if vcs.elements["fontNumber"][self.tt.font] == font:
-                button.set_state(1)
-            self.font_buttons[font] = button
+        font_editor = FontEditor(self.toolbar, self.set_font, vcs.elements["fontNumber"][self.tt.font])
 
         self.picker = None
         self.toolbar.add_button(["Change Color"], action=self.change_color)
@@ -105,11 +86,7 @@ class LabelEditor(point.PointEditor):
             vcs.vcs2vtk.prepTextProperty(p,winSize,to=self.to,tt=self.tt,cmap=None)
 
     def set_font(self, font):
-        current_font = vcs.getfontname(self.tt.font)
-        if font != current_font:
-            self.font_buttons[current_font].set_state(0)
         self.tt.font = font
-        self.font_buttons[font].set_state(1)
         self.save()
 
     def halign(self, state):

--- a/Packages/vcs/Lib/editors/text.py
+++ b/Packages/vcs/Lib/editors/text.py
@@ -6,7 +6,7 @@ from vcs.vtk_ui.behaviors import ClickableMixin
 import priority
 import vcs
 from vcs.vcs2vtk import genTextActor
-from functools import partial
+from font import FontEditor
 
 __valign_map__ = {
     0: 0,
@@ -47,27 +47,8 @@ class TextEditor(ClickableMixin, priority.PriorityEditor):
         valign.set_state(__valign_map__[self.text.valign])
 
         self.toolbar.add_slider_button(text.angle, 0, 360, "Angle", update=self.update_angle)
-        self.fonts = sorted(vcs.elements["font"].keys())
 
-        font_toolbar = self.toolbar.add_toolbar("Fonts")
-
-        self.font_buttons = {}
-
-        def font_setter(font):
-            return partial(self.set_font, font)
-
-        deactivate = font_setter("default")
-
-        for ind, font in enumerate(self.fonts):
-
-            if font[:4] != "Math":
-                button = font_toolbar.add_toggle_button(font, on=font_setter(font), off=deactivate, font=vcs.elements["font"][font])
-            else:
-                button = font_toolbar.add_toggle_button(font, on=font_setter(font), off=deactivate)
-
-            if vcs.elements["fontNumber"][self.text.font] == font:
-                button.set_state(1)
-            self.font_buttons[font] = button
+        font_editor = FontEditor(self.toolbar, self.set_font, vcs.elements["fontNumber"][self.text.font])
 
         self.picker = None
         self.toolbar.add_button(["Change Color"], action=self.change_color)
@@ -86,11 +67,7 @@ class TextEditor(ClickableMixin, priority.PriorityEditor):
         self.update()
 
     def set_font(self, font):
-        current_font = vcs.getfontname(self.text.font)
-        if font != current_font:
-            self.font_buttons[current_font].set_state(0)
         self.text.font = font
-        self.font_buttons[font].set_state(1)
         self.update()
 
     def get_object(self):


### PR DESCRIPTION
Eliminates the scenario that leads to the segfault in #1093 by replacing the font menu with a font button. Instead of getting previews of all of the fonts, you get a single button that cycles through the different fonts. Less good, but less crash-prone.

I extracted font selection out into a separate class so when we actually fix the root of #1093 it should be pretty easy to bring back the more complicated but more user-friendly UI. We can either leave #1093 open (and move to 2.3) or closed (and create an enhancement request to add a menu for fonts); I'd lean towards the latter.