### PR TITLE
Adding Dockerfiles for generating docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+Packages/DV3D/demo
+Packages/visus/ext-libs
+Packa
+Packages/demo
+Packages/cmor/Test
+contrib/ZonalMeans/Test
+Packages/vcs_legacy
+Packages/WK/Test
+contrib/HDF5Tools/Examples
+Packages/cmor/Doc

--- a/CMake/dashboard/docker.cmake
+++ b/CMake/dashboard/docker.cmake
@@ -1,0 +1,21 @@
+set(CTEST_SOURCE_DIRECTORY /usr/src/uvcdat)
+set(CTEST_BINARY_DIRECTORY /tmp/uvcdat-build)
+
+include(${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake)
+set(CTEST_SITE "Docker Ubuntu:14.04")
+set(CTEST_BUILD_NAME "nogui-master")
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+
+ctest_start("Experimental")
+ctest_configure(OPTIONS "-DCDAT_BUILD_WEB=ON;-DCDAT_BUILD_GUI=OFF;-DCDAT_BUILD_OSMESA=ON;-DCDAT_BUILD_OFFSCREEN=ON;-DCMAKE_INSTALL_PREFIX=/opt/uvcdat")
+ctest_build()
+ctest_test(PARALLEL_LEVEL 4 RETURN_VALUE res)
+ctest_coverage()
+file(REMOVE "${CTEST_BINARY_DIRECTORY}/coverage.xml")
+ctest_submit()
+
+file(REMOVE "${CTEST_BINARY_DIRECTORY}/test_failed")
+if(NOT res EQUAL 0)
+  file(WRITE "${CTEST_BINARY_DIRECTORY}/test_failed" "error")
+  message(FATAL_ERROR "Test failures occurred.")
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM uvcdat/ubuntu
+MAINTAINER UV-CDAT Developers <uvcdat-support@llnl.gov>
+
+RUN mkdir -p /tmp/uvcdat-build
+ADD . /usr/src/uvcdat
+RUN cd /tmp/uvcdat-build && cmake -DCDAT_BUILD_WEB=ON -DCDAT_BUILD_GUI=OFF -DCDAT_BUILD_OSMESA=ON -DCDAT_BUILD_OFFSCREEN=ON -DCMAKE_INSTALL_PREFIX=/opt/uvcdat /usr/src/uvcdat && make && cd / && rm -fr /tmp/uvcdat-build
+
+RUN useradd -d /data -m -U uvcdat
+
+VOLUME /data
+WORKDIR /data
+USER uvcdat
+
+ENV UVCDAT_SETUP_PATH /opt/uvcdat
+ENV PATH $UVCDAT_SETUP_PATH/bin:$UVCDAT_SETUP_PATH/Externals/bin:$PATH
+ENV PYTHONPATH $UVCDAT_SETUP_PATH/lib/python2.7/site-packages:$UVCDAT_SETUP_PATH/Externals/lib/python2.7/site-packages
+ENV LD_LIBRARY_PATH $UVCDAT_SETUP_PATH/lib:$UVCDAT_SETUP_PATH/Externals/lib
+ENV UVCDAT_ANONYMOUS_LOG no

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,5 +49,5 @@ Note that UV-CDAT probably won't build with the standard VM setup by `boot2docke
 may need to increase the memory and disk size when initializing.  For example, to create a VM with 4 GB of RAM and 
 50 GB of disk space:
 ```
-boot2docker --memory=4096 -disksize=50000
+boot2docker --memory=4096 --disksize=50000
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,46 @@
+UV-CDAT Docker images
+=====================
+
+Docker images of UV-CDAT are available at [docker hub](https://registry.hub.docker.com/u/uvcdat/uvcdat/).  These
+images are built with offscreen rendering and no GUI support due to limitations in docker; however, it is possible
+to render images from UV-CDAT scripts or directly using the commandline interface.  The primary motivation for
+the creation of these images is for easy deployment of visualization servers for CDATWeb, but users may find
+them useful for quick image generation or data exploration without needing to build and configure the UV-CDAT
+environment.
+
+To try using the latest version of UV-CDAT, first [install](https://docs.docker.com/compose/install/) Docker
+for your platform.  Note, Docker runs natively on Linux, but requires a lightweight virtual machine on Mac and
+Windows.  The management of this virtual machine is handled through the `boot2docker` command.  Typically,
+you will need to start up the virtual machine with `boot2docker start` and configure the environment with
+`$(boot2docker shellinit)`.  See the docker installation guide for more information.
+
+Running uvcdat once docker is set up is easy:
+```
+docker run -i -t uvcdat/uvcdat ipython
+```
+This will download the docker image, run it in a new container, and give an ipython shell inside the container.
+From here, you can import all python modules that are shipped with the CLI version of UV-CDAT.
+
+Building the docker images
+--------------------------
+
+The `Dockerfile` for building UV-CDAT is stored at the root level of this repository.  It is built on top of
+a custom Ubuntu 14.04 install containing all necessary dependencies.  Generally it will not be necessary to
+rebuild this base image, but if new packages are necessary from apt, they can be added to `docker/ubuntu/Dockerfile`
+and the image rebuilt with `docker build -t uvcdat/ubuntu`.
+
+When updating master, a new `uvcdat/uvcdat:latest` should be generated and pushed to docker hub.  The
+build should be initiated from a clean checkout of the repository to avoid adding unnecessary files to the
+image.  From the top level of the repository, issue the following command to build the image.
+```
+docker build -t uvcdat/uvcdat .
+```
+Once it is built successfully you can test the image with ctest and upload the results to
+[CDash](https://open.cdash.org/index.php?project=UV-CDAT&display=project) with
+```
+docker run ctest -S /usr/src/uvcdat/CMake/dashboard/docker.cmake -VV
+```
+Finally, if you have push access to the docker hub account, you can push the image up to docker.
+```
+docker push uvcdat/uvcdat
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -44,3 +44,10 @@ Finally, if you have push access to the docker hub account, you can push the ima
 ```
 docker push uvcdat/uvcdat
 ```
+
+Note that UV-CDAT probably won't build with the standard VM setup by `boot2docker`.  If you get build errors, you
+may need to increase the memory and disk size when initializing.  For example, to create a VM with 4 GB of RAM and 
+50 GB of disk space:
+```
+boot2docker --memory=4096 -disksize=50000
+```

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:14.04
+MAINTAINER UV-CDAT Developers <uvcdat-support@llnl.gov>
+
+RUN apt-get update && apt-get install -y git gfortran g++ libffi-dev libsqlite-dev libssl-dev libbz2-dev libexpat-dev ncurses-dev curl make wget libjpeg-dev libpng-dev
+
+RUN curl http://www.cmake.org/files/v3.2/cmake-3.2.0-rc2-Linux-x86_64.tar.gz | tar -v -C /opt -zx
+
+ENV PATH /opt/cmake-3.2.0-rc2-Linux-x86_64/bin:$PATH


### PR DESCRIPTION
For some information, see the [README](https://github.com/UV-CDAT/uvcdat/blob/docker/docker/README.md) I included.  Docker hub has a system for autogenerating builds from github pushes, but it isn't working here due to some cryptic timeout error.  I assume the VM it builds on doesn't have enough memory or disk space.  For now, we will have to update images manually from time to time (ideally with every push to master).