### PR TITLE
Target will now detach when configurator detaches

### DIFF
--- a/Packages/vcs/Lib/configurator.py
+++ b/Packages/vcs/Lib/configurator.py
@@ -279,6 +279,10 @@ class Configurator(object):
             self.marker_button.detach()
             self.marker_button = None
 
+        if self.target is not None:
+            self.target.detach()
+            self.target = None
+
         if self.animation_timer is not None:
             self.stop_animating()
 


### PR DESCRIPTION
Fixes a bug where if you had an editor open when ending configuration (as can happen in the GUI, when you close the Configure menu), the editor would remain open.