### PR TITLE
Fixes ubuntu error that showed up for charles

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -50,14 +50,15 @@ class VTKVCSBackend(object):
     self._plot_keywords = [ 'renderer','vtk_backend_grid','vtk_backend_geo', 'cdmsfile', 'cell_coordinates' ]
     self.numberOfPlotCalls = 0
     self.renderWindowSize=None
+    self.clickRenderer = None
 
     if renWin is not None:
       self.renWin = renWin
       if renWin.GetInteractor() is None and self.bg is False:
         self.createDefaultInteractor()
+
     if sys.platform == "darwin":
         self.reRender = False
-        self.clickRenderer = None
         self.oldCursor = None
 
 
@@ -175,7 +176,7 @@ class VTKVCSBackend(object):
     ren.AddActor(a2d)
     ren.AddActor(a)
     ren.ResetCamera()
-    self.clickRenderer= ren
+    self.clickRenderer = ren
     self.renWin.AddRenderer(ren)
     self.renWin.Render()
 


### PR DESCRIPTION
Occasionally, depending on when you clicked during initialization, an exception would happen about clickRenderer not being defined– this should fix that issue (I've tested it on my ubuntu and it seems to work).