### PR TITLE
Mac control click fixes

### DIFF
--- a/Packages/vcs/Lib/editors/marker.py
+++ b/Packages/vcs/Lib/editors/marker.py
@@ -5,6 +5,7 @@ from vcs.VCS_validation_functions import checkMarker
 import vtk
 import vcs.vcs2vtk
 import priority
+import sys
 
 class MarkerEditor(behaviors.ClickableMixin, behaviors.DraggableMixin, priority.PriorityEditor):
     """
@@ -61,7 +62,8 @@ class MarkerEditor(behaviors.ClickableMixin, behaviors.DraggableMixin, priority.
         prop.SetBackgroundColor(.87, .79, .55)
         prop.SetBackgroundOpacity(1)
         prop.SetColor(0, 0, 0)
-        self.tooltip = vtk_ui.Label(self.interactor, "Ctrl + Click to place new markers.", textproperty=prop)
+
+        self.tooltip = vtk_ui.Label(self.interactor, "%s + Click to place new markers." % "Cmd" if sys.platform == "darwin" else "Ctrl", textproperty=prop)
         self.tooltip.left = 0
         self.tooltip.top = self.interactor.GetRenderWindow().GetSize()[1] - self.tooltip.get_dimensions()[1]
         self.tooltip.show()
@@ -73,7 +75,7 @@ class MarkerEditor(behaviors.ClickableMixin, behaviors.DraggableMixin, priority.
 
     def handle_click(self, point):
         x, y = point
-        # Alt drops a new instance
+        # Control drops a new instance
         return self.in_bounds(x, y) or self.toolbar.in_toolbar(x, y) or self.current_modifiers()["control"]
 
     def is_object(self, marker):
@@ -136,7 +138,6 @@ class MarkerEditor(behaviors.ClickableMixin, behaviors.DraggableMixin, priority.
 
     def click_release(self):
         x, y = self.event_position()
-
         if self.current_modifiers()["control"]:
             h = vtk_ui.Handle(self.interactor, (x, y), dragged=self.adjust, color=(0,0,0), normalize=True)
             h.show()

--- a/Packages/vcs/Lib/editors/marker.py
+++ b/Packages/vcs/Lib/editors/marker.py
@@ -63,7 +63,7 @@ class MarkerEditor(behaviors.ClickableMixin, behaviors.DraggableMixin, priority.
         prop.SetBackgroundOpacity(1)
         prop.SetColor(0, 0, 0)
 
-        self.tooltip = vtk_ui.Label(self.interactor, "%s + Click to place new markers." % "Cmd" if sys.platform == "darwin" else "Ctrl", textproperty=prop)
+        self.tooltip = vtk_ui.Label(self.interactor, "%s + Click to place new markers." % ("Cmd" if sys.platform == "darwin" else "Ctrl"), textproperty=prop)
         self.tooltip.left = 0
         self.tooltip.top = self.interactor.GetRenderWindow().GetSize()[1] - self.tooltip.get_dimensions()[1]
         self.tooltip.show()

--- a/Packages/vcs/Lib/editors/text.py
+++ b/Packages/vcs/Lib/editors/text.py
@@ -59,7 +59,7 @@ class TextEditor(ClickableMixin, priority.PriorityEditor):
         prop.SetBackgroundColor(.87, .79, .55)
         prop.SetBackgroundOpacity(1)
         prop.SetColor(0, 0, 0)
-        self.tooltip = Label(self.interactor, "%s + Click to place new text." % "Cmd" if sys.platform == "darwin" else "Ctrl", textproperty=prop)
+        self.tooltip = Label(self.interactor, "%s + Click to place new text." % ("Cmd" if sys.platform == "darwin" else "Ctrl"), textproperty=prop)
         self.tooltip.left = 0
         self.tooltip.top = self.interactor.GetRenderWindow().GetSize()[1] - self.tooltip.get_dimensions()[1]
         self.tooltip.show()

--- a/Packages/vcs/Lib/editors/text.py
+++ b/Packages/vcs/Lib/editors/text.py
@@ -7,6 +7,7 @@ import priority
 import vcs
 from vcs.vcs2vtk import genTextActor
 from font import FontEditor
+import sys
 
 __valign_map__ = {
     0: 0,
@@ -58,7 +59,7 @@ class TextEditor(ClickableMixin, priority.PriorityEditor):
         prop.SetBackgroundColor(.87, .79, .55)
         prop.SetBackgroundOpacity(1)
         prop.SetColor(0, 0, 0)
-        self.tooltip = Label(self.interactor, "Ctrl + Click to place new text.", textproperty=prop)
+        self.tooltip = Label(self.interactor, "%s + Click to place new text." % "Cmd" if sys.platform == "darwin" else "Ctrl", textproperty=prop)
         self.tooltip.left = 0
         self.tooltip.top = self.interactor.GetRenderWindow().GetSize()[1] - self.tooltip.get_dimensions()[1]
         self.tooltip.show()


### PR DESCRIPTION
Some minor help text fixes in regards to issues associated with #1163– working on the PR for vistrails to fix these issues. Mac is going to use Command + click, linux will use control + click. I would use control + click on mac, but QT sees that as a right click (which is fair, that's pretty standard-ish behavior for a mac app), so there's no way to map that correctly to VTK. Instead I'm going to use command (which is mapped to control on mac in QT for reasons unbeknownst to me), and I'm working on fixing some associated issues with that in VisTrails. This PR can be merged whenever; it's not dependent on the VisTrails half.