### PR TITLE
Fixed some VTK error messages that showed up when ending configure

### DIFF
--- a/Packages/vcs/Lib/configurator.py
+++ b/Packages/vcs/Lib/configurator.py
@@ -292,8 +292,6 @@ class Configurator(object):
         # if all of the widgets have been cleaned up correctly, this will delete the manager
         vtk_ui.manager.delete_manager(self.interactor)
 
-        self.interactor.Render()
-
     def release(self, object, event):
         if self.clicking is None:
             return

--- a/Packages/vcs/Lib/vtk_ui/manager.py
+++ b/Packages/vcs/Lib/vtk_ui/manager.py
@@ -78,6 +78,7 @@ class InterfaceManager(object):
             w.detach()
         if self.window.HasRenderer(self.renderer):
             self.window.RemoveRenderer(self.renderer)
+        self.renderer.RemoveAllViewProps()
         self.interactor.RemoveObserver(self.timer_listener)
         self.window.RemoveObserver(self.window_mod)
         self.window.RemoveObserver(self.render_listener)

--- a/Packages/vcs/Lib/vtk_ui/manager.py
+++ b/Packages/vcs/Lib/vtk_ui/manager.py
@@ -79,6 +79,7 @@ class InterfaceManager(object):
         if self.window.HasRenderer(self.renderer):
             self.window.RemoveRenderer(self.renderer)
         self.renderer.RemoveAllViewProps()
+        self.renderer = None
         self.interactor.RemoveObserver(self.timer_listener)
         self.window.RemoveObserver(self.window_mod)
         self.window.RemoveObserver(self.render_listener)


### PR DESCRIPTION
Should hopefully fix @williams13's VTK error messages; managed to reproduce them locally and eliminated them. They cropped up when closing the configure menu when a bunch of plots were open.