### PR TITLE
Fix ratio resizing issue

### DIFF
--- a/Packages/vcs/Lib/configurator.py
+++ b/Packages/vcs/Lib/configurator.py
@@ -210,57 +210,21 @@ class Configurator(object):
                 self.init_toolbar()
 
         self.displays = [vcs.elements["display"][display] for display in self.canvas.display_names]
-
         for display in self.displays:
 
             if display._template_origin in self.templates:
-                # Adjust data coords if display.ratio is not none
-                if display.ratio is not None:
-                    t = vcs.gettemplate(display.template)
-                    orig = vcs.gettemplate(self.templates[display._template_origin])
-                    t.data._ratio  = -999.
-                    t.data._x1     = orig.data._x1
-                    t.data._x2     = orig.data._x2
-                    t.data._y1     = orig.data._y1
-                    t.data._y2     = orig.data._y2
-                    t.box1._x1     = orig.box1._x1
-                    t.box1._x2     = orig.box1._x2
-                    t.box1._y1     = orig.box1._y1
-                    t.box1._y2     = orig.box1._y2
-                    t.xlabel1._y   = orig.xlabel1._y
-                    t.xlabel2._y   = orig.xlabel2._y
-                    t.xtic2._y1    = orig.xtic2._y1
-                    t.ylabel1._x   = orig.ylabel1._x
-                    t.ytic1._x1    = orig.ytic1._x1
-                    t.ylabel2._x   = orig.ylabel2._x
-                    t.ytic2._x1    = orig.ytic2._x1
-                    t.xtic1._y2    = orig.xtic1._y2
-                    t.xtic1._y1    = orig.xtic1._y1
-                    t.data._y1     = orig.data._y1
-                    t.xtic1.y1     = orig.xtic1.y1
-                    t.xtic2._y2    = orig.xtic2._y2
-                    t.data._y2     = orig.data._y2
-                    t.xtic2.y1     = orig.xtic2.y1
-                    t.xmintic1._y2 = orig.xmintic1._y2
-                    t.xmintic1._y1 = orig.xmintic1._y1
-                    t.xmintic2._y2 = orig.xmintic2._y2
-                    t.xmintic2._y1 = orig.xmintic2._y1
-                    t.ytic1._x2    = orig.ytic1._x2
-                    t.data._x1     = orig.data._x1
-                    t.ytic2._x2    = orig.ytic2._x2
-                    t.data._x2     = orig.data._x2
-                    t.ymintic1._x2 = orig.ymintic1._x2
-                    t.ymintic1._x1 = orig.ymintic1._x1
-                    t.ymintic2._x2 = orig.ymintic2._x2
-                    t.ymintic2._x1 = orig.ymintic2._x1
-                # It already has a template we created
                 continue
-            # Manufacture a placeholder template to use for updates
-            new_template = vcs.createtemplate(source=display.template)
-            self.templates[new_template.name] = display.template
-            display.template = new_template.name
-            # This is an attribute used internally; might break
-            display._template_origin = new_template.name
+
+            if display.ratio is not None:
+                # Ratio'd displays already have a temporary template
+                self.templates[display.template] = display._template_origin
+            else:
+                # Manufacture a placeholder template to use for updates
+                new_template = vcs.createtemplate(source=display.template)
+                self.templates[new_template.name] = display.template
+                display.template = new_template.name
+                # This is an attribute used internally; might break
+                display._template_origin = new_template.name
 
     def detach(self):
         if self.toolbar is not None:


### PR DESCRIPTION
Currently, when you resize a plot that has a ratio in `interact()` mode, things go badly.

```python
import vcs, cdms2
datafile = cdms2.open(vcs.prefix + "/sample_data/clt.nc")
clt = datafile("clt")

x = vcs.init()
x.plot(clt, ratio="autot")
x.interact()
```

Here's how the plot looks when you first make it (Perfectly correct)
![screen shot 2015-03-27 at 11 57 35 am](https://cloud.githubusercontent.com/assets/718512/6874979/bb8751ba-d478-11e4-8a0a-f56009e7206d.png)

Here's how it looks when you shrink the window (Not too bad...)
![screen shot 2015-03-27 at 11 57 50 am](https://cloud.githubusercontent.com/assets/718512/6874980/bb87cdc0-d478-11e4-8240-cf2c5520389c.png)

But hey, let's compare that to another plot that was actually plotted at that window size, for giggles...

```python
# press "Q", resume execution
y = vcs.init()
# You can plot whatever here, it doesn't matter initially
y.plot(clt)
# Just needed to get the window open...
y.clear()
# Resize to the size of x's window
y.backend.renWin.SetSize(x.backend.renWin.GetSize())
y.plot(clt, ratio="autot")
raw_input("Huh, would you look at that...")
```
Here's the x canvas' plot:
![screen shot 2015-03-27 at 11 57 50 am](https://cloud.githubusercontent.com/assets/718512/6874980/bb87cdc0-d478-11e4-8240-cf2c5520389c.png)

Here's the y canvas' plot:
![screen shot 2015-03-27 at 11 58 00 am](https://cloud.githubusercontent.com/assets/718512/6875029/322a534e-d479-11e4-8f74-280a4ae00ab4.png)

While we can debate whether the labels should run over each other like that, the second behavior is the "correct" behavior, as the resizing in the first window only happens while in interact mode.

This PR should fix this issue– I looked into it, and plots given a ratio actually already generate a new template. My system was snagging that copied template, and then using it as the basis for a new template. This would cause some cascading error in the resizing logic, which is why the resize came out weird. Since the template is already a copy, I can just add the original and the copy into the existing store of templates. As a happy side effect, the code got a lot shorter and less wacky.

@doutriaux1 @aashish24 Mind taking a look?
