### PR TITLE
Fix for clear and close for DV3D plots

### DIFF
--- a/Packages/DV3D/DV3DPlot.py
+++ b/Packages/DV3D/DV3DPlot.py
@@ -314,9 +314,10 @@ class DV3DPlot():
         self.onWindowModified()
 
     def onClosing(self, cell ):
-        print " ------> Closing!"
+        #print " ------> Closing!"
         self.stopAnimation()
-        self.cfgManager.parent.clear( cell )
+        if self.cfgManager.parent:
+            self.cfgManager.parent.clear( cell )
         self.terminate()
         self.renderer.RemoveAllViewProps()
         self.clearReferrents()

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -247,16 +247,20 @@ class VTKVCSBackend(object):
     renderers.InitTraversal()
     ren = renderers.GetNextItem()
     hasValidRenderer = True if ren is not None else False
+
+    for gm in self.plotApps:
+      app = self.plotApps[gm]
+      app.plot.quit()
+
     self.hideGUI()
     while ren is not None:
-        if not ren in self.plotRenderers:
-            ren.RemoveAllViewProps()
-            if not ren.GetLayer()==0:
-              self.renWin.RemoveRenderer(ren)
-            else:
-              #Update background color
-              r,g,b = [c / 255. for c in self.canvas.backgroundcolor]
-              ren.SetBackground(r,g,b)
+        ren.RemoveAllViewProps()
+        if not ren.GetLayer()==0:
+          self.renWin.RemoveRenderer(ren)
+        else:
+          #Update background color
+          r,g,b = [c / 255. for c in self.canvas.backgroundcolor]
+          ren.SetBackground(r,g,b)
         ren = renderers.GetNextItem()
     self.showGUI()
     if hasValidRenderer and self.renWin.IsDrawable() and render:


### PR DESCRIPTION
Fix for part of #1188 – `x.clear` and `x.close` now work appropriately.