### PR TITLE
Made slider jump instead of animate, added test

### DIFF
--- a/Packages/vcs/Lib/vtk_ui/slider.py
+++ b/Packages/vcs/Lib/vtk_ui/slider.py
@@ -50,7 +50,7 @@ class Slider(Widget):
         self.repr.SetTitleHeight( 0.02 )
         self.repr.SetTitleText(title)
 
-        sliderWidget.SetAnimationModeToAnimate()
+        sliderWidget.SetAnimationModeToJump()
 
         sliderWidget.AddObserver("EndInteractionEvent", self.end_slide)
         sliderWidget.AddObserver("InteractionEvent", self.slide_value)

--- a/testing/vcs/vtk_ui/CMakeLists.txt
+++ b/testing/vcs/vtk_ui/CMakeLists.txt
@@ -65,3 +65,9 @@ add_test(test_vtk_ui_button_tooltip_hide
   ${TEST_DIR}/test_vtk_ui_button_tooltip_hide.py
   ${BASELINE_DIR}/test_vtk_ui_button_tooltip_hide.png
 )
+
+add_test(test_vtk_ui_slider_jumps
+  "${PYTHON_EXECUTABLE}"
+  ${TEST_DIR}/test_vtk_ui_slider_jumps.py
+  ${BASELINE_DIR}/test_vtk_ui_slider_jumps.png
+)

--- a/testing/vcs/vtk_ui/test_vtk_ui_slider_jumps.py
+++ b/testing/vcs/vtk_ui/test_vtk_ui_slider_jumps.py
@@ -1,0 +1,29 @@
+"""
+Test slider jumps to new values instead of animating
+"""
+import vcs.vtk_ui
+from time import sleep
+from vtk_ui_test import vtk_ui_test
+
+class test_vtk_ui_slider_jumps(vtk_ui_test):
+    def __init__(self):
+        self.failed = False
+        self.updated = False
+        super(test_vtk_ui_slider_jumps, self).__init__()
+    def do_test(self):
+        self.win.SetSize(100, 100)
+
+        slider = vcs.vtk_ui.Slider(self.inter, value=0, min_val=0, max_val=5, point1=(0, .5), point2=(1, .5), update=self.update_test)
+        slider.show()
+
+        self.click_event(80, 50)
+        if self.failed:
+            self.passed = 1
+        else:
+            self.passed = 0
+
+    def update_test(self, value):
+        if value < 4:
+            self.failed = True
+
+test_vtk_ui_slider_jumps().test()


### PR DESCRIPTION
Made sliders jump to clicked positions instead of animating; it was super slow and annoying. To test, plot a variable, start interact, and open up the animation submenu from the configure menu. Open the time slider, and click on the slider anywhere besides the slide toggle. It should jump straight there.