### PR TITLE
Fix #1197

### DIFF
--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -541,6 +541,8 @@ class Canvas(object,AutoAPI.AutoAPI):
       self._savedcontinentstype = value
 
     def onClosing( self, cell  ):
+        if self.configurator:
+            self.endconfigure()
         self.backend.onClosing( cell )
 
     def _reconstruct_tv(self, arglist, keyargs):
@@ -3843,6 +3845,8 @@ Options:::
 """
         if self.animate.created():
             self.animate.close()
+        if self.configurator is not None:
+            self.configurator.stop_animating()
         self.animate_info=[]
         self.animate.update_animate_display_list( )
         self.backend.clear(*args,**kargs)

--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -3883,7 +3883,8 @@ Options:::
         #if (self.canvas_gui is not None):
         #   self.canvas_gui.dialog.dialog.withdraw() # just withdraw the GUI for later
         #   gui_canvas_closed = 0
-
+        if self.configurator:
+            self.endconfigure()
         # Close the VCS Canvas
         a = self.backend.close(*args,**kargs)
 

--- a/Packages/vcs/Lib/configurator.py
+++ b/Packages/vcs/Lib/configurator.py
@@ -227,6 +227,9 @@ class Configurator(object):
                 display._template_origin = new_template.name
 
     def detach(self):
+        if self.interactor is None:
+            return
+
         if self.animation_timer is not None:
             self.stop_animating()
 

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -511,4 +511,8 @@ cdat_add_test(vcs_test_taylor_2_quads
       )
   endif()
 
+cdat_add_test(vcs_test_endconfigure
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_endconfigure.py
+)
 add_subdirectory(vtk_ui)

--- a/testing/vcs/test_vcs_endconfigure.py
+++ b/testing/vcs/test_vcs_endconfigure.py
@@ -1,0 +1,37 @@
+import vcs, sys
+
+class FakeConfigurator(object):
+    def __init__(self):
+        self.detached = False
+
+    def detach(self):
+        self.detached = True
+
+x = vcs.init()
+
+fake = FakeConfigurator()
+
+x.configurator = fake
+x.close()
+
+if x.configurator is not None:
+    print "x.close() did not end configuration"
+    sys.exit(1)
+
+if fake.detached == False:
+    print "x.close() did not detach configurator"
+    sys.exit(1)
+
+fake = FakeConfigurator()
+x.configurator = fake
+x.onClosing(None)
+
+if x.configurator is not None:
+    print "x.onClosing did not end configuration"
+    sys.exit(1)
+
+if fake.detached == False:
+    print "x.onClosing() did not detach configurator"
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
Fix for #1197; adds a test that makes sure the configurator is cleaned up when the canvas is closed / the GUI kills a canvas.