### PR TITLE
VTK_UI Tests no longer segfault on Ubuntu (and other X based systems)

### DIFF
--- a/Packages/vcs/Lib/vtk_ui/manager.py
+++ b/Packages/vcs/Lib/vtk_ui/manager.py
@@ -42,6 +42,12 @@ class InterfaceManager(object):
             self.window.Render()
 
     def queue_render(self):
+        if not self.interactor.GetInitialized():
+            print "Not initialized"
+            self.timer = 1
+            self.__render(None, None)
+            return
+
         if self.timer is None:
             # approximately one frame at 60 fps
             self.timer = self.interactor.CreateOneShotTimer(16)

--- a/Packages/vcs/Lib/vtk_ui/manager.py
+++ b/Packages/vcs/Lib/vtk_ui/manager.py
@@ -43,7 +43,6 @@ class InterfaceManager(object):
 
     def queue_render(self):
         if not self.interactor.GetInitialized():
-            print "Not initialized"
             self.timer = 1
             self.__render(None, None)
             return


### PR DESCRIPTION
Fix for #1208; I was calling `CreateOneShotTimer` on an uninitialized `vtkXRenderWindowInteractor`, which led to segfaults on Ubuntu (and presumably other X-based systems). Now the `InterfaceManager` will check if the interactor is initialized before trying that, and will jut call render on the RenderWindow if it is not.