### PR TITLE
Allow open/interact without plotting anything

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -85,6 +85,7 @@ class VTKVCSBackend(object):
           warnings.warn("Cannot start interaction. Blank plot?")
           return
       warnings.warn("Press 'Q' to exit interactive mode and continue script execution")
+      self.showGUI()
       interactor.Start()
 
   def endEvent(self,obj,event):
@@ -296,9 +297,11 @@ class VTKVCSBackend(object):
 
     if self.renderer == None:
       self.renderer = self.createRenderer()
-      if self.bg is False:
+      if self.bg != True:
           self.createDefaultInteractor(self.renderer)
       self.renWin.AddRenderer(self.renderer)
+    if "open" in kargs and kargs["open"]:
+      self.renWin.Render()
 
   def createRenderer(self, *args, **kargs):
       # For now always use the canvas background
@@ -1435,7 +1438,7 @@ class VTKVCSBackend(object):
 
     if plot:
         plot.hideWidgets()
-    elif self.bg is False:
+    elif self.bg != True:
       from vtk_ui.manager import get_manager, manager_exists
       if manager_exists(self.renWin.GetInteractor()):
           manager = get_manager(self.renWin.GetInteractor())
@@ -1446,7 +1449,7 @@ class VTKVCSBackend(object):
 
     if plot:
         plot.showWidgets()
-    elif self.bg is False:
+    elif self.bg != True:
       from vtk_ui.manager import get_manager, manager_exists
       if manager_exists(self.renWin.GetInteractor()):
           manager = get_manager(self.renWin.GetInteractor())

--- a/Packages/vcs/Lib/configurator.py
+++ b/Packages/vcs/Lib/configurator.py
@@ -339,7 +339,7 @@ class Configurator(object):
         self.clicking = (self.interactor.GetEventPosition(), datetime.datetime.now())
 
     def show(self):
-        if len(self.displays) == 0:
+        if self.interactor is None:
             return
         self.place()
         self.toolbar.show()

--- a/testing/vcs/test_vcs_interact_no_plot.py
+++ b/testing/vcs/test_vcs_interact_no_plot.py
@@ -1,6 +1,21 @@
-
 import vcs
-x=vcs.init()
+import sys
+
+x = vcs.init()
 x.drawlogooff()
 x.open()
+
+inter = x.backend.renWin.GetInteractor()
+
+
+def end_interact(obj, event):
+    print "Interaction began"
+    inter.TerminateApp()
+    sys.exit(0)
+
+inter.AddObserver("StartEvent", end_interact)
 x.interact()
+
+# Should not reach this point
+print "Did not start interact."
+sys.exit(1)


### PR DESCRIPTION
Currently, the `canvas.open()` call doesn't do anything. In developing and testing my GUI parts embedded in VCS, it's really quite handy to have a fully-prepared VCS canvas without actually plotting anything (or plotting something and then calling `clear()`, which gives the same end result). This PR makes it so you can open the canvas prior to plotting. As a caveat of that, if you call `x.open(); x.interact()`, it'll now enter interact mode. This is a *little* goofy, but given the fact that we have some GUI elements that allow for some user interaction with a blank canvas (markers and text buttons, top right), it's not completely ridiculous. I'm happy to scrap the ability to `interact()` with a blank canvas; it's not particularly useful for me.

All of the tests pass for me with this PR, though there is one test that will hang until manually quit (`test_vcs_interact_no_plot.py`). If we make it so `interact()` will fail when there are no plots, that test can remain the same; if we don't, this test will either have to change or be eliminated.

@doutriaux1 @aashish24 @dlonie  Opinions?