### PR TITLE
Fixed resizing issue and added two tests to cover it

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1478,6 +1478,7 @@ class VTKVCSBackend(object):
       if manager_exists(self.renWin.GetInteractor()):
           manager = get_manager(self.renWin.GetInteractor())
           self.renWin.RemoveRenderer(manager.renderer)
+          self.renWin.RemoveRenderer(manager.actor_renderer)
 
   def showGUI(self, render=True):
     plot = self.get3DPlot()
@@ -1489,6 +1490,7 @@ class VTKVCSBackend(object):
       if manager_exists(self.renWin.GetInteractor()):
           manager = get_manager(self.renWin.GetInteractor())
           self.renWin.AddRenderer(manager.renderer)
+          self.renWin.AddRenderer(manager.actor_renderer)
           # Bring the manager's renderer to the top of the stack
           manager.elevate()
       if render:

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -630,4 +630,10 @@ cdat_add_test(vcs_test_configurator_click_marker
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_configurator_click_marker.py
 )
+cdat_add_test(vcs_test_configurator_resize
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_configurator_resize.py
+  ${BASELINE_DIR}/test_vcs_configurator_resize.png
+)
+
 add_subdirectory(vtk_ui)

--- a/testing/vcs/test_vcs_configurator_resize.py
+++ b/testing/vcs/test_vcs_configurator_resize.py
@@ -1,0 +1,29 @@
+import vcs, vtk
+
+x = vcs.init()
+x.open()
+x.configure()
+
+x.backend.renWin.SetSize(814, 303)
+x.backend.renWin.Modified()
+
+fnm = "test_vcs_configurator_resize.png"
+
+win = x.backend.renWin
+win.Render()
+out_filter = vtk.vtkWindowToImageFilter()
+out_filter.SetInput(win)
+
+png_writer = vtk.vtkPNGWriter()
+png_writer.SetFileName(fnm)
+png_writer.SetInputConnection(out_filter.GetOutputPort())
+png_writer.Write()
+
+import sys, os
+if len(sys.argv) > 1:
+    pth = os.path.join(os.path.dirname(__file__), "..")
+    sys.path.append(pth)
+    import checkimage
+    src = sys.argv[1]
+    ret = checkimage.check_result_image(fnm, src, checkimage.defaultThreshold)
+    sys.exit(ret)

--- a/testing/vcs/vtk_ui/CMakeLists.txt
+++ b/testing/vcs/vtk_ui/CMakeLists.txt
@@ -167,3 +167,9 @@ add_test(test_vtk_ui_white_or_black
   "${PYTHON_EXECUTABLE}"
   ${TEST_DIR}/test_vtk_ui_white_or_black.py
 )
+
+add_test(test_vtk_ui_manager_resize
+  "${PYTHON_EXECUTABLE}"
+  ${TEST_DIR}/test_vtk_ui_manager_resize.py
+  ${BASELINE_DIR}/test_vtk_ui_manager_resize.png
+)

--- a/testing/vcs/vtk_ui/test_vtk_ui_manager_resize.py
+++ b/testing/vcs/vtk_ui/test_vtk_ui_manager_resize.py
@@ -1,0 +1,26 @@
+"""
+Test window resizing placing widgets correctly
+"""
+import vcs.vtk_ui
+
+from vtk_ui_test import vtk_ui_test
+
+
+class test_vtk_ui_manager_resize(vtk_ui_test):
+    def do_test(self):
+        self.win.SetSize(250, 100)
+        # Due to UV-CDAT/uvcdat#1148, have to render on screen when resizing
+        self.win.SetOffScreenRendering(0)
+
+        button = vcs.vtk_ui.Button(self.inter, label="Position me", left=10, top=10)
+        button.place()
+        button.show()
+
+        self.win.SetSize(200, 50)
+
+        self.win.Modified()
+
+        self.test_file = "test_vtk_ui_manager_resize.png"
+
+if __name__ == "__main__":
+    test_vtk_ui_manager_resize().test()


### PR DESCRIPTION
This fixes #1241 (I forgot to add the new `actor_renderer` to the show/hide gui commands, which made my labels get removed from the render window on resize events). The tests cover resizing in VCS as well as pure VTK; helped me narrow down the cause.

@aashish24 are we submitting PRs against release or master?