### PR TITLE
Colorpicker now uses manager correctly

### DIFF
--- a/Packages/vcs/Lib/colorpicker.py
+++ b/Packages/vcs/Lib/colorpicker.py
@@ -38,7 +38,10 @@ class ColorPicker(object):
         self.style = vtk.vtkInteractorStyleUser()
         inter.SetInteractorStyle(self.style)
         inter.SetRenderWindow(self.render_window)
-
+        manager = vcs.vtk_ui.manager.get_manager(inter)
+        self.render_window.AddRenderer(manager.renderer)
+        self.render_window.AddRenderer(manager.actor_renderer)
+        manager.elevate()
         self.render_window.Render()
 
         self.on_save = on_save

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -630,4 +630,9 @@ cdat_add_test(vcs_test_configurator_click_marker
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_configurator_click_marker.py
 )
+cdat_add_test(vcs_test_colorpicker_appearance
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_colorpicker_appearance.py
+  ${BASELINE_DIR}/test_vcs_colorpicker_appearance.png
+)
 add_subdirectory(vtk_ui)

--- a/testing/vcs/test_vcs_colorpicker_appearance.py
+++ b/testing/vcs/test_vcs_colorpicker_appearance.py
@@ -1,0 +1,23 @@
+import vcs, vtk
+
+picker = vcs.colorpicker.ColorPicker(500, 250, None, 0)
+
+win = picker.render_window
+
+win.Render()
+out_filter = vtk.vtkWindowToImageFilter()
+out_filter.SetInput(win)
+
+png_writer = vtk.vtkPNGWriter()
+fnm = "test_vcs_colorpicker_appearance.png"
+png_writer.SetFileName(fnm)
+png_writer.SetInputConnection(out_filter.GetOutputPort())
+png_writer.Write()
+
+import sys, os
+if len(sys.argv) > 1:
+    src = sys.argv[1]
+    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+    import checkimage
+    ret = checkimage.check_result_image(fnm, src, checkimage.defaultThreshold)
+    sys.exit(ret)


### PR DESCRIPTION
Colorpicker was not displaying the widgets that it should have; fixed this issue, added a test for basic appearance to make sure it looks the same. Goes with UV-CDAT/uvcdat-testdata#42