### PR TITLE
Colorpicker renderer selection

### DIFF
--- a/Packages/vcs/Lib/colorpicker.py
+++ b/Packages/vcs/Lib/colorpicker.py
@@ -117,7 +117,7 @@ class ColorPicker(object):
         self.close()
 
     def selectCell(self, cellId):
-        if cellId == -1:
+        if cellId in (None, -1):
             return
         ids = vtk.vtkIdTypeArray();
         ids.SetNumberOfComponents(1);

--- a/Packages/vcs/Lib/colorpicker.py
+++ b/Packages/vcs/Lib/colorpicker.py
@@ -149,7 +149,7 @@ class ColorPicker(object):
 
         x, y = inter.GetEventPosition()
 
-        renderer = self.topRendererAtPoint(x, y)
+        renderer = self.color_renderer
 
         if renderer:
             picker = vtk.vtkCellPicker()

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -618,6 +618,11 @@ cdat_add_test(vcs_test_endconfigure
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_endconfigure.py
 )
 
+cdat_add_test(vcs_test_colorpicker_selection
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_colorpicker_selection.py
+)
+
 cdat_add_test(vcs_test_configurator_click_text
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_configurator_click_text.py

--- a/testing/vcs/test_vcs_colorpicker_selection.py
+++ b/testing/vcs/test_vcs_colorpicker_selection.py
@@ -1,0 +1,19 @@
+import vcs, sys
+
+passing = False
+
+
+def save_clicked(colormap, color):
+    if color == 135:
+        global passing
+        passing = True
+
+
+picker = vcs.colorpicker.ColorPicker(500, 500, None, None, on_save=save_clicked)
+
+interactor = picker.render_window.GetInteractor()
+interactor.SetEventInformation(250, 260)
+picker.clickEvent(None, None)
+picker.save(0)
+
+sys.exit(0 if passing else 1)


### PR DESCRIPTION
ColorPicker was selecting the top renderer at the point clicked on, which was incorrect; it should just use the color_renderer. Fixed this issue, added test to make sure that it can select a color appropriately.

https://open.cdash.org/viewTest.php?buildid=3795002