### PR TITLE
Add lapack to libcf deps

### DIFF
--- a/CMake/cdat_modules/libcf_deps.cmake
+++ b/CMake/cdat_modules/libcf_deps.cmake
@@ -1,1 +1,1 @@
-set(libcf_deps ${pkgconfig_pkg} ${python_pkg} ${netcdf_pkg} ${hdf5_pkg} ${curl_pkg} ${zlib_pkg} ${uuid_pkg} )
+set(libcf_deps ${pkgconfig_pkg} ${python_pkg} ${netcdf_pkg} ${hdf5_pkg} ${curl_pkg} ${zlib_pkg} ${uuid_pkg} ${clapack_pkg} ${lapack_pkg} )


### PR DESCRIPTION
This should fix the [`testAccuracy`](https://open.cdash.org/testDetails.php?test=334081753&build=3803139) error we were seeing on garant.