### PR TITLE
Vtk master bump

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1141,7 +1141,6 @@ class VTKVCSBackend(object):
             ports=vtkobjects["vtk_backend_glyphfilters"]
             w = vcs2vtk.generateVectorArray(array1,array2,vg)
             vg.GetPointData().AddArray(w)
-            vg = vcs2vtk.stripGrid(vg)
             ports[0].SetInputData(vg)
 
           if vtkobjects.has_key("vtk_backend_actors"):

--- a/Packages/vcs/Lib/editors/text.py
+++ b/Packages/vcs/Lib/editors/text.py
@@ -93,7 +93,9 @@ class TextEditor(ClickableMixin, priority.PriorityEditor):
             del self.textboxes
 
         self.textboxes = []
-        w, h = self.interactor.GetRenderWindow().GetSize()
+        renWin = self.interactor.GetRenderWindow()
+        w, h = renWin.GetSize()
+        dpi = renWin.GetDPI()
         cmap = vcs.getcolormap()
 
         prop = vtkTextProperty()
@@ -106,7 +108,8 @@ class TextEditor(ClickableMixin, priority.PriorityEditor):
             y = self.text.y[ind]
             string = self.text.string[ind]
 
-            text_width, text_height = text_dimensions(self.text, ind, (w, h))
+            text_width, text_height = text_dimensions(self.text, ind, (w, h),
+                                                      dpi)
 
             x = x * w
             y = y * h
@@ -291,7 +294,7 @@ class TextEditor(ClickableMixin, priority.PriorityEditor):
         self.render()
 
 
-def text_dimensions(text, index, winsize):
+def text_dimensions(text, index, winsize, dpi):
     prop = vtkTextProperty()
     vcs.vcs2vtk.prepTextProperty(prop, winsize, text, text, vcs.getcolormap())
-    return vcs.vtk_ui.text.text_dimensions(text.string[index], prop)
+    return vcs.vtk_ui.text.text_dimensions(text.string[index], prop, dpi)

--- a/Packages/vcs/Lib/vcs2vtk.py
+++ b/Packages/vcs/Lib/vcs2vtk.py
@@ -1434,35 +1434,6 @@ def generateVectorArray(data1,data2,vtk_grid):
     w.SetName("vectors")
     return w
 
-def stripGrid(vtk_grid):
-    # Strip out masked points.
-    if vtk_grid.IsA("vtkStructuredGrid"):
-        if vtk_grid.GetCellBlanking():
-            visArray = vtk_grid.GetCellVisibilityArray()
-            visArray.SetName("BlankingArray")
-            vtk_grid.GetCellData().AddArray(visArray)
-            thresh = vtk.vtkThreshold()
-            thresh.SetInputData(vtk_grid)
-            thresh.ThresholdByUpper(0.5)
-            thresh.SetInputArrayToProcess(0, 0, 0,
-                                          "vtkDataObject::FIELD_ASSOCIATION_CELLS",
-                                          "BlankingArray")
-            thresh.Update()
-            vtk_grid = thresh.GetOutput()
-        elif vtk_grid.GetPointBlanking():
-            visArray = vtk_grid.GetPointVisibilityArray()
-            visArray.SetName("BlankingArray")
-            vtk_grid.GetPointData().AddArray(visArray)
-            thresh = vtk.vtkThreshold()
-            thresh.SetInputData(vtk_grid)
-            thresh.SetUpperThreshold(0.5)
-            thresh.SetInputArrayToProcess(0, 0, 0,
-                                          "vtkDataObject::FIELD_ASSOCIATION_POINTS",
-                                          "BlankingArray")
-            thresh.Update()
-            vtk_grid = thresh.GetOutput()
-    return vtk_grid
-
 def vtkIterate(iterator):
     iterator.InitTraversal()
     obj = iterator.GetNextItem()

--- a/Packages/vcs/Lib/vcsvtk/vectorpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/vectorpipeline.py
@@ -61,8 +61,6 @@ class VectorPipeline(Pipeline):
         if gm.linecolor is not None:
             lcolor = gm.linecolor
 
-        grid = vcs2vtk.stripGrid(grid)
-
         arrow = vtk.vtkGlyphSource2D()
         arrow.SetGlyphTypeToArrow()
         arrow.FilledOff()

--- a/Packages/vcs/Lib/vtk_ui/button.py
+++ b/Packages/vcs/Lib/vtk_ui/button.py
@@ -180,6 +180,7 @@ class Button(Widget):
 
     def update(self):
         self.repr.SetNumberOfStates(len(self.states))
+        dpi = self.interactor.GetRenderWindow().GetDPI()
 
         max_width = 0
         max_height = 0
@@ -197,7 +198,9 @@ class Button(Widget):
                 max_width = max(max_width, w)
 
             elif label_text:
-                l_w, l_h = text_dimensions(label_text, self.text_widget.actor.GetTextProperty())
+                l_w, l_h = text_dimensions(
+                      label_text, self.text_widget.actor.GetTextProperty(),
+                      dpi)
 
                 max_height = max(max_height, l_h)
                 max_width = max(max_width, l_w)

--- a/Packages/vcs/Lib/vtk_ui/text.py
+++ b/Packages/vcs/Lib/vtk_ui/text.py
@@ -172,13 +172,13 @@ def text_actor(string, fgcolor, size, font):
     return actor
 
 
-def text_dimensions(text, text_prop, at_angle=0):
+def text_dimensions(text, text_prop, dpi, at_angle=0):
     ren = vtkTextRenderer()
     bounds = [0, 0, 0, 0]
     p = vtkTextProperty()
     p.ShallowCopy(text_prop)
     p.SetOrientation(at_angle)
-    ren.GetBoundingBox(p, text, bounds)
+    ren.GetBoundingBox(p, text, bounds, dpi)
     return bounds[1] - bounds[0] + 1, bounds[3] - bounds[2] + 1
 
 
@@ -253,7 +253,8 @@ class Label(Widget, DraggableMixin, ClickableMixin):
         if halign == "Left":
             return self.x
 
-        w, h = text_dimensions(self.text, self.actor.GetTextProperty())
+        dpi = self.interactor.GetRenderWindow().GetDPI()
+        w, h = text_dimensions(self.text, self.actor.GetTextProperty(), dpi)
         if halign == "Centered":
             return self.x - math.floor(w / 2.)
 
@@ -266,7 +267,8 @@ class Label(Widget, DraggableMixin, ClickableMixin):
         if halign == "Left":
             self.x = l
 
-        w, h = text_dimensions(self.text, self.actor.GetTextProperty())
+        dpi = self.interactor.GetRenderWindow().GetDPI()
+        w, h = text_dimensions(self.text, self.actor.GetTextProperty(), dpi)
         if halign == "Centered":
             self.x = l + math.floor(w / 2.)
 
@@ -276,7 +278,8 @@ class Label(Widget, DraggableMixin, ClickableMixin):
     @property
     def top(self):
         """The top side of the text actor, adjusted by height/justification"""
-        w, h = text_dimensions(self.text, self.actor.GetTextProperty())
+        dpi = self.interactor.GetRenderWindow().GetDPI()
+        w, h = text_dimensions(self.text, self.actor.GetTextProperty(), dpi)
         valign = self.actor.GetTextProperty().GetVerticalJustificationAsString()
         y = self.y
         # Adjust from alignment point to top of the actor
@@ -296,7 +299,8 @@ class Label(Widget, DraggableMixin, ClickableMixin):
         Sets actor y using distance in pixels from top of window to top of actor
         """
         # Get the text's size to adjust for alignment
-        w, h = text_dimensions(self.text, self.actor.GetTextProperty())
+        dpi = self.interactor.GetRenderWindow().GetDPI()
+        w, h = text_dimensions(self.text, self.actor.GetTextProperty(), dpi)
 
         valign = self.actor.GetTextProperty().GetVerticalJustificationAsString()
         # Adjust position based on alignment

--- a/Packages/vcs/Lib/vtk_ui/textbox.py
+++ b/Packages/vcs/Lib/vtk_ui/textbox.py
@@ -201,14 +201,16 @@ class Textbox(Label):
 
         rows = self.text.split("\n")
 
-        width, height = text_dimensions(self.text, prop)
+        dpi = self.interactor.GetRenderWindow().GetDPI()
+        width, height = text_dimensions(self.text, prop, dpi)
         line_height = float(height) / len(rows)
 
-        column_adjustment, _ = text_dimensions(rows[self.row][:self.column], prop)
+        column_adjustment, _ = text_dimensions(rows[self.row][:self.column],
+                                               prop, dpi)
 
         x += column_adjustment
 
-        row_width, _ = text_dimensions(rows[self.row], prop)
+        row_width, _ = text_dimensions(rows[self.row], prop, dpi)
 
         # Adjust for blank space caused by justifications
         halign = prop.GetJustificationAsString()
@@ -256,7 +258,8 @@ class Textbox(Label):
         rows = self.text.split("\n")
         prop = self.actor.GetTextProperty()
 
-        text_width, text_height = text_dimensions(self.text, prop)
+        dpi = self.interactor.GetRenderWindow().GetDPI()
+        text_width, text_height = text_dimensions(self.text, prop, dpi)
 
         # Viewport coordinates of widget
         sw, sh = self.interactor.GetRenderWindow().GetSize()
@@ -292,7 +295,7 @@ class Textbox(Label):
             else:
                 dim_row = row
 
-            w, h = text_dimensions(dim_row, prop)
+            w, h = text_dimensions(dim_row, prop, dpi)
             row_bounds.append((w, h))
 
             if w > max_width:
@@ -344,7 +347,7 @@ class Textbox(Label):
         w = 0
         ind = 1
         while row_left + w < x:
-            w, _ = text_dimensions(text[:ind], prop)
+            w, _ = text_dimensions(text[:ind], prop, dpi)
             ind += 1
 
         return row_at_point, ind - 1

--- a/testing/vcs/vtk_ui/test_vtk_ui_label_bounds.py
+++ b/testing/vcs/vtk_ui/test_vtk_ui_label_bounds.py
@@ -9,10 +9,12 @@ from vtk_ui_test import vtk_ui_test
 class test_vtk_ui_label_bounds(vtk_ui_test):
     def do_test(self):
         self.win.SetSize(130, 40)
+        dpi = self.win.GetDPI()
 
         l = vcs.vtk_ui.Label(self.inter, "Testing", fgcolor=(0, 0, 0), size=24, font="Arial")
         l.show()
-        w, h = vcs.vtk_ui.text.text_dimensions("Testing", l.actor.GetTextProperty())
+        w, h = vcs.vtk_ui.text.text_dimensions("Testing",
+                                               l.actor.GetTextProperty(), dpi)
 
         left = l.left
 

--- a/testing/vcs/vtk_ui/test_vtk_ui_text_dimensions.py
+++ b/testing/vcs/vtk_ui/test_vtk_ui_text_dimensions.py
@@ -12,18 +12,22 @@ class test_vtk_ui_text_dimensions(vtk_ui_test):
         text_property = vtk.vtkTextProperty()
         text_property.SetFontFamilyToArial()
         text_property.SetFontSize(24)
+        dpi = self.win.GetDPI()
 
-        w, h = vcs.vtk_ui.text.text_dimensions("no descenders", text_property)
+        w, h = vcs.vtk_ui.text.text_dimensions("no descenders", text_property,
+                                               dpi)
         if w != 175 or h != 24:
             print "no descenders width/height changed"
             return
 
-        w, h = vcs.vtk_ui.text.text_dimensions("couple good descenders", text_property)
+        w, h = vcs.vtk_ui.text.text_dimensions("couple good descenders",
+                                               text_property, dpi)
         if w != 299 or h != 24:
             print "couple good descenders width/height changed"
             return
 
-        w, h = vcs.vtk_ui.text.text_dimensions("This one\nis on\nmultiple lines", text_property)
+        w, h = vcs.vtk_ui.text.text_dimensions(
+              "This one\nis on\nmultiple lines", text_property, dpi)
         if w != 151 or h != 76:
             print "Multi-line width/height changed"
             return


### PR DESCRIPTION
Update code to work with new VTK master. See commit messages for details of changes.

This PR requires the following changes to the following repos:
- VTK needs to use UV-CDAT/VTK#5
- uvcdat-testdata needs UV-CDAT/uvcdat-testdata#53

**I'm missing one baseline from the testdata patch.** I'm on arch, so the dv3d vector test fails for me (https://open.cdash.org/testDetails.php?test=339707560&build=3831990). Can someone run that test with this uvcdat/vtk and send me a baseline with the new text, but not the line. IIRC the bug doesn't affect ubuntu or mac.

This PR should also be manually tested, since the buildbots won't pick up the VTK change.

@doutriaux1 @chaosphere2112 