### PR TITLE
Disable multisampling on vtk_ui tests.

### DIFF
--- a/testing/vcs/vtk_ui/vtk_ui_test.py
+++ b/testing/vcs/vtk_ui/vtk_ui_test.py
@@ -10,6 +10,7 @@ def init():
 
     win.SetNumberOfLayers(3)
     win.SetSize(100, 250)
+    win.SetMultiSamples(0)
 
     inter = vtk.vtkRenderWindowInteractor()
     inter.SetRenderWindow(win)


### PR DESCRIPTION
Otherwise we get inconsistent results across platforms and GL implementations.

Fixes #1359.

@doutriaux1 @aashish24 @chaosphere2112 