### PR TITLE
Sync the uvcdat-testdata branch with the uvcdat branch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ if(BUILD_TESTING)
       "-DGIT_EXECUTABLE=${GIT_EXECUTABLE}"
       "-DTESTDATA_URL=${REPO_URL}"
       "-DTESTDATA_DIR=${UVCDAT_GIT_TESTDATA_DIR}"
+      "-DSOURCE_DIR=${cdat_SOURCE_DIR}"
       -P "${cdat_CMAKE_SOURCE_DIR}/cdat_modules_extra/checkout_testdata.cmake"
     COMMENT "Updating uvcdat-testdata repo."
   )


### PR DESCRIPTION
If no matching remote is found, the master branch is used.

If the source repo is not on a named branch, master is used.

If the testdata checkout is dirty, no action is performed.

Fixes #1361.

@aashish24 @jbeezley @doutriaux1 This should allow buildbot to fetch branch-specific testdata.