### PR TITLE
Added a sleep for onscreen rendered tests

### DIFF
--- a/testing/vcs/vtk_ui/vtk_ui_test.py
+++ b/testing/vcs/vtk_ui/vtk_ui_test.py
@@ -91,6 +91,12 @@ class vtk_ui_test(object):
         self.do_test()
 
         if self.test_file:
+            if self.win.GetOffScreenRendering() == 0:
+                # There was a race condition where resizing might take longer
+                # than rendering, so the image was coming out weird. This
+                # should fix that.
+                from time import sleep
+                sleep(2)
             if self.args:
                 src = self.args[0]
                 self.passed = self.check_image(src)


### PR DESCRIPTION
This should help generalize what @durack1 did in #1341 (adding a sleep to handle the race condition with resized windows). The root of the issue is #1148; I have some tests that resize the window (to make sure everything is well-behaved), and because of #1148 they have to be rendered onscreen. This makes them run slowly, which looks like it adds a race condition– see intermittent failures of the resize manager and background color tests. This makes it so the base class checks if the window is set to render offscreen; if it isn't, it will sleep.