### PR TITLE
Fix tag detection for git clone/update scripts

### DIFF
--- a/CMake/cdat_modules_extra/git_clone.sh.in
+++ b/CMake/cdat_modules_extra/git_clone.sh.in
@@ -3,7 +3,7 @@
 cd "@CMAKE_INSTALL_PREFIX@"
 "@GIT_EXECUTABLE@" clone --no-checkout --depth 1 -b @BRANCH@ @GIT_URL@ "@GIT_TARGET@"
 cd "@GIT_TARGET@"
-if [ "$("@GIT_EXECUTABLE@" cat-file -t @BRANCH@)" = tag ]; then
+if "@GIT_EXECUTABLE@" rev-parse --symbolic-full-name @BRANCH@ | grep -q '^refs/tags/'; then
     "@GIT_EXECUTABLE@" checkout @BRANCH@
 else
     "@GIT_EXECUTABLE@" checkout origin/@BRANCH@

--- a/CMake/cdat_modules_extra/git_update.sh.in
+++ b/CMake/cdat_modules_extra/git_update.sh.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd "@SOURCE_DIR@"
 "@GIT_EXECUTABLE@" fetch origin --prune
-if [ "$("@GIT_EXECUTABLE@" cat-file -t @BRANCH@)" = tag ]; then
+if "@GIT_EXECUTABLE@" rev-parse --symbolic-full-name @BRANCH@ | grep -q '^refs/tags/'; then
     "@GIT_EXECUTABLE@" checkout -f @BRANCH@
 else
     "@GIT_EXECUTABLE@" checkout -f origin/@BRANCH@


### PR DESCRIPTION
Amends #993

Checking that the object type is "tag" only works for annotated tags. If case someone decides to make a lightweight tag (or does it by mistake), it will now correctly be handled.

Interestingly, this only seems to be used by 'vistrails', so I don't think it will fix build warnings like:
```
[INFO] [PIP] Installing UVCMETRICS from GIT_REPOSITORY;git://github.com/UV-CDAT/uvcmetrics.git
fatal: ambiguous argument 'origin/uvcdat-2.2.0': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
which I think just leak through from ExternalProject but are not actual errors(?)