### PR TITLE
no reason anymore to force pip at low version

### DIFF
--- a/CMake/cdat_modules/pip_pkg.cmake
+++ b/CMake/cdat_modules/pip_pkg.cmake
@@ -1,6 +1,6 @@
-set(PIP_MAJOR_SRC 1)
-set(PIP_MINOR_SRC 2)
-set(PIP_PATCH_SRC 1)
+set(PIP_MAJOR_SRC 7)
+set(PIP_MINOR_SRC 1)
+set(PIP_PATCH_SRC 0)
 
 set (nm PIP)
 string(TOUPPER ${nm} uc_nm)
@@ -8,6 +8,6 @@ set(${uc_nm}_VERSION ${${nm}_MAJOR_SRC}.${${nm}_MINOR_SRC}.${${nm}_PATCH_SRC})
 set(PIP_URL ${LLNL_URL})
 set(PIP_GZ pip-${PIP_VERSION}.tar.gz)
 set(PIP_SOURCE ${PIP_URL}/${PIP_GZ})
-set(PIP_MD5 db8a6d8a4564d3dc7f337ebed67b1a85)
+set(PIP_MD5 d935ee9146074b1d3f26c5f0acfd120e)
 
 add_cdat_package(pip "" "" OFF)


### PR DESCRIPTION
we used to do that because of firewall forcing us to pass certificates to pip
but now we send sources to pip so the problem does not exist any longer