### PR TITLE
Fix library problem when compiling python 2.7 and using VIM 7.4. Add …

### DIFF
--- a/CMake/cdat_modules_extra/python_configure_step.cmake.in
+++ b/CMake/cdat_modules_extra/python_configure_step.cmake.in
@@ -31,7 +31,8 @@ endif()
 if(APPLE)
   set(library_param --prefix=@CMAKE_INSTALL_PREFIX@ --enable-framework=@CMAKE_INSTALL_PREFIX@/Library/Frameworks)
 elseif(UNIX)
-  set(library_param --prefix=@CMAKE_INSTALL_PREFIX@ --enable-shared)
+  set(library_param --prefix=@CMAKE_INSTALL_PREFIX@ --enable-shared --enable-unicode=ucs4)
+
 endif()
 
 EXECUTE_PROCESS(


### PR DESCRIPTION
…--enable-unicode=ucs4