### PR TITLE
Dramatically cuts down on the number of renderers used per plot

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -322,7 +322,7 @@ class VTKVCSBackend(object):
             self.renWin.Render()
 
     def createRenderer(self, *args, **kargs):
-            # For now always use the canvas background
+        # For now always use the canvas background
         ren = vtk.vtkRenderer()
         r, g, b = self.canvas.backgroundcolor
         ren.SetBackground(r / 255., g / 255., b / 255.)
@@ -492,6 +492,7 @@ class VTKVCSBackend(object):
             if gm.priority != 0:
                 actors = vcs2vtk.prepLine(self.renWin, gm)
                 returned["vtk_backend_line_actors"] = actors
+                create_renderer = True
                 for act, geo in actors:
                     ren = self.fitToViewport(
                         act,
@@ -499,11 +500,13 @@ class VTKVCSBackend(object):
                         wc=gm.worldcoordinate,
                         geo=geo,
                         priority=gm.priority,
-                        create_renderer=True)
+                        create_renderer=create_renderer)
+                    create_renderer = False
         elif gtype == "marker":
             if gm.priority != 0:
                 actors = vcs2vtk.prepMarker(self.renWin, gm)
                 returned["vtk_backend_marker_actors"] = actors
+                create_renderer = True
                 for g, gs, pd, act, geo in actors:
                     ren = self.fitToViewport(
                         act,
@@ -512,6 +515,7 @@ class VTKVCSBackend(object):
                         geo=geo,
                         priority=gm.priority,
                         create_renderer=True)
+                    create_renderer = False
                     if pd is None and act.GetUserTransform():
                         vcs2vtk.scaleMarkerGlyph(g, gs, pd, act)
 
@@ -519,6 +523,7 @@ class VTKVCSBackend(object):
             if gm.priority != 0:
                 actors = vcs2vtk.prepFillarea(self.renWin, gm)
                 returned["vtk_backend_fillarea_actors"] = actors
+                create_renderer = True
                 for act, geo in actors:
                     ren = self.fitToViewport(
                         act,
@@ -526,7 +531,8 @@ class VTKVCSBackend(object):
                         wc=gm.worldcoordinate,
                         geo=geo,
                         priority=gm.priority,
-                        create_renderer=True)
+                        create_renderer=create_renderer)
+                    create_renderer = False
         else:
             raise Exception(
                 "Graphic type: '%s' not re-implemented yet" %
@@ -1075,7 +1081,8 @@ class VTKVCSBackend(object):
 
     def fitToViewport(self, Actor, vp, wc=None, geo=None, priority=None,
                       create_renderer=False):
-            # Data range in World Coordinates
+
+        # Data range in World Coordinates
         if priority == 0:
             return None
         vp = tuple(vp)


### PR DESCRIPTION
Hey all...

I was poking around in the latest off of master, and I bumped into a quite impressive regression in interactivity. Since I haven't touched `vtk_ui` in a while, I did some digging.

It looks like the regression was caused by the hatch/patterns PR; in particular, these are the troublesome lines:

https://github.com/UV-CDAT/uvcdat/blob/fc1660a30a6bdbafb5ee200cfeebd55f519ecb74/Packages/vcs/Lib/VTKPlots.py#L491-L529

which come from this commit:

https://github.com/UV-CDAT/uvcdat/commit/66465b5de8662c966a6049fc841c494d41ec11f0

The issue, as far as I can tell, is that this adds 300 `vtkRenderer`s to the render window (where previously there were 18). The main offender is the color bar, which apparently is rendered as a couple hundred fill areas with a pile of lines. All of these renderers dramatically increase the amount of time spent using `vtkPropPicker`, which is presumably the main cause of the slow down.

I made it so the primitives being generated will all use the same renderer for the many actors generated for that primitive. This brought the renderer count back down to like 27, which is a *lot* more reasonable than 300.
