### PR TITLE
Fix for #1517

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1075,7 +1075,7 @@ class VTKVCSBackend(object):
 
     def fitToViewport(self, Actor, vp, wc=None, geo=None, priority=None,
                       create_renderer=False):
-            # Data range in World Coordinates
+        # Data range in World Coordinates
         if priority == 0:
             return None
         vp = tuple(vp)

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -170,6 +170,7 @@ class VTKVCSBackend(object):
         ren.SetBackground(.96, .96, .86)
         ren.SetViewport(x, y, min(x + .2, 1.), min(y + .2, 1))
         ren.SetLayer(self.renWin.GetNumberOfLayers() - 1)
+        self.renWin.AddRenderer(ren)
         a = vtk.vtkTextActor()
         a.SetInput(st)
         p = a.GetProperty()
@@ -190,7 +191,6 @@ class VTKVCSBackend(object):
         ren.AddActor(a)
         ren.ResetCamera()
         self.clickRenderer = ren
-        self.renWin.AddRenderer(ren)
         self.renWin.Render()
 
     def leftButtonReleaseEvent(self, obj, event):

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1075,7 +1075,7 @@ class VTKVCSBackend(object):
 
     def fitToViewport(self, Actor, vp, wc=None, geo=None, priority=None,
                       create_renderer=False):
-        # Data range in World Coordinates
+            # Data range in World Coordinates
         if priority == 0:
             return None
         vp = tuple(vp)

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -719,5 +719,11 @@ cdat_add_test(vcs_test_colorpicker_appearance
   ${BASELINE_DIR}/test_vcs_colorpicker_appearance.png
 )
 
+cdat_add_test(vcs_test_click_info
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_click_info.py
+  ${BASELINE_DIR}/test_vcs_click_info.png
+)
+
 add_subdirectory(vtk_ui)
 add_subdirectory(editors)

--- a/testing/vcs/test_vcs_click_info.py
+++ b/testing/vcs/test_vcs_click_info.py
@@ -1,0 +1,31 @@
+import cdms2
+import sys
+import vcs
+import os
+
+src = sys.argv[1]
+pth = os.path.join(os.path.dirname(__file__), "..")
+sys.path.append(pth)
+import checkimage
+x = vcs.init()
+x.setantialiasing(0)
+x.drawlogooff()
+f = cdms2.open(vcs.sample_data + "/clt.nc")
+s = f("clt")
+
+# Has to plot in foreground to simulate a click
+x.plot(s)
+
+# Simulate a click -- VTK Specific
+i = x.backend.renWin.GetInteractor()
+i.SetEventInformation(200, 200)
+i.LeftButtonPressEvent()
+
+fnm = "test_vcs_click_info.png"
+
+x.png(fnm)
+
+print "fnm:", fnm
+print "src:", src
+ret = checkimage.check_result_image(fnm, src, checkimage.defaultThreshold)
+sys.exit(ret)


### PR DESCRIPTION
Fixes #1517 by moving the AddRenderer call in backend.leftButtonPressEvent before actors get added; the issue was because we were querying the text actor's bounding box information, which requires it to be in a render chain (apparently a new requirement vs older versions of vtk). Added a test to (hopefully) keep this feature working reliably in the future. Goes with UV-CDAT/uvcdat-testdata#63.