### PR TITLE
uvcdat script now will redirect all output appropriately

### DIFF
--- a/CMake/cdat_modules_extra/uvcdat.in
+++ b/CMake/cdat_modules_extra/uvcdat.in
@@ -38,6 +38,9 @@ do
                   # Do not redirect output
     --output-std) redirect=false
             ;;
+            # Shouldn't redirect for help
+    --help) redirect=false
+            ;;
     *)      ;;
     esac
 done

--- a/CMake/cdat_modules_extra/uvcdat.in
+++ b/CMake/cdat_modules_extra/uvcdat.in
@@ -25,7 +25,7 @@ do
             redirect=false
         fi
             ;;
-        --output-std) redirect=false
+    --output-std) redirect=false
               ;;
     *) ;;
     esac

--- a/CMake/cdat_modules_extra/uvcdat.in
+++ b/CMake/cdat_modules_extra/uvcdat.in
@@ -1,4 +1,40 @@
 #!/bin/bash
 # source is not portable whereas . is
 . "@CMAKE_INSTALL_PREFIX@/bin/setup_runtime.sh"
-python@PYVER@ "@CMAKE_INSTALL_PREFIX@/vistrails/vistrails/uvcdat.py" "$@"
+
+capture=false
+target="$HOME/.uvcdat/uvcdatsession.log"
+redirect=true
+
+for var in "$@"
+do
+    if [ $capture = true ]; then
+        target=$var
+        if [ "$target" = "" ]; then
+            redirect=false
+        fi
+        capture=false
+        continue
+    fi
+
+    case $var in
+    -o) capture=true;
+            ;;
+    --output=*) target=`sed "s/--output=\(.*\)/\1/" <<< $var`
+        if [ "$target" = "" ]; then
+            redirect=false
+        fi
+            ;;
+        --output-std) redirect=false
+              ;;
+    *) ;;
+    esac
+done
+
+if [ $redirect = false ]  ;then
+    python@PYVER@ "@CMAKE_INSTALL_PREFIX@/vistrails/vistrails/uvcdat.py" "$@"
+else
+    target="${target/#\~/$HOME}"
+    touch $target
+    python@PYVER@ "@CMAKE_INSTALL_PREFIX@/vistrails/vistrails/uvcdat.py" "$@" >>$target 2>&1
+fi

--- a/CMake/cdat_modules_extra/uvcdat.in
+++ b/CMake/cdat_modules_extra/uvcdat.in
@@ -2,39 +2,53 @@
 # source is not portable whereas . is
 . "@CMAKE_INSTALL_PREFIX@/bin/setup_runtime.sh"
 
+# Used in event of -o "log_location"; grabs the next arg and puts it in target
 capture=false
+# The location we'll be logging to
 target="$HOME/.uvcdat/uvcdatsession.log"
+# Whether or not we're redirecting the stdout/stderr
 redirect=true
 
 for var in "$@"
 do
     if [ $capture = true ]; then
+        # -o was found, grabbing the next value
         target=$var
         if [ "$target" = "" ]; then
+            # This is the way we can redirect output to stdout
+            # Do not redirect output
             redirect=false
         fi
+        # Don't need to capture anything else
         capture=false
         continue
     fi
 
     case $var in
+        # Trigger above block on the next arg
     -o) capture=true;
             ;;
+                # Parse the target out of the = section
     --output=*) target=`sed "s/--output=\(.*\)/\1/" <<< $var`
         if [ "$target" = "" ]; then
+            # Do not redirect output
             redirect=false
         fi
             ;;
+                  # Do not redirect output
     --output-std) redirect=false
-              ;;
-    *) ;;
+            ;;
+    *)      ;;
     esac
 done
 
 if [ $redirect = false ]  ;then
     python@PYVER@ "@CMAKE_INSTALL_PREFIX@/vistrails/vistrails/uvcdat.py" "$@"
 else
+    # Replace all uses of ~ with $HOME
     target="${target/#\~/$HOME}"
+    # Make sure the file exists and that we have write privileges
     touch $target
+    # Launch with redirection
     python@PYVER@ "@CMAKE_INSTALL_PREFIX@/vistrails/vistrails/uvcdat.py" "$@" >>$target 2>&1
 fi


### PR DESCRIPTION
Fixes #1239; parses arguments passed to UV-CDAT, detects where output should be sent, and redirects all stdout and stderr to append at that location (in addition to the standard UV-CDAT logging mechanisms that are already printing at that point). Should fix the issues we've been having with miscellaneous C++ level logging getting dumped to the console (like the annoying Qt modal window non-error).