### PR TITLE
Make Isoline respect linewidths and line attributes

### DIFF
--- a/Packages/vcs/Lib/vcsvtk/isolinepipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/isolinepipeline.py
@@ -6,6 +6,15 @@ import vcs
 import vtk
 
 
+LINE_PATTERNS = {
+    "solid": 0xFFFF,
+    "dash": 0xF0F0,
+    "dot": 0xCCCC,
+    "dash-dot": 0xE4E4,
+    "long-dash": 0xFCFC
+}
+
+
 class IsolinePipeline(Pipeline2D):
 
     """Implementation of the Pipeline interface for VCS isoline plots."""
@@ -208,8 +217,11 @@ class IsolinePipeline(Pipeline2D):
 
         # And now we need actors to actually render this thing
         actors = []
-        for mapper in mappers:
+        for index, mapper in enumerate(mappers):
             act = vtk.vtkActor()
+            actor_property = act.GetProperty()
+            actor_property.SetLineWidth(self._gm.linewidths[index])
+            actor_property.SetLineStipplePattern(LINE_PATTERNS[self._gm.line[index]])
             act.SetMapper(mapper)
 
             if self._vtkGeoTransform is None:


### PR DESCRIPTION
I started work on this fix for #1625, but it quickly got out of my VTK depth. @sankhesh, I stubbed in the logic for applying the width and patterns (and I built the patterns for you, so you don't have to futz with those). Mind making this work properly and apply only to specific levels?

I was planning on doing a per-level vtkContourFilter > vtkPolyDataMapper > vtkActor and setting the property appropriately for each of those, but if there's a better way then by all means, do so.