### PR TITLE
VTK Performance Improvements

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -38,6 +38,8 @@ class VTKVCSBackend(object):
         self.type = "vtk"
         self.plotApps = {}
         self.plotRenderers = set()
+        # Maps priorities to renderers
+        self.text_renderers = {}
         self.logoRenderer = None
         self.logoRepresentation = None
         self.renderer = None
@@ -267,6 +269,7 @@ class VTKVCSBackend(object):
         renderers = self.renWin.GetRenderers()
         renderers.InitTraversal()
         ren = renderers.GetNextItem()
+        self.text_renderers = {}
         hasValidRenderer = True if ren is not None else False
 
         for gm in self.plotApps:
@@ -325,6 +328,10 @@ class VTKVCSBackend(object):
             self.renWin.Render()
 
     def createRenderer(self, *args, **kargs):
+        """import inspect
+        c = inspect.currentframe()
+        caller = inspect.getouterframes(c)
+        print "createRenderer called by", caller[1][3], caller[1][2]"""
         # For now always use the canvas background
         ren = vtk.vtkRenderer()
         r, g, b = self.canvas.backgroundcolor
@@ -510,19 +517,20 @@ class VTKVCSBackend(object):
             returned.update(self.plot3D(data1, data2, tpl, gm, ren, **kargs))
         elif gtype in ["text"]:
             if tt.priority != 0:
-                # if not (None,None,None) in self._renderers.keys():
-                ren = self.createRenderer()
-                self.renWin.AddRenderer(ren)
-                self.setLayer(ren, 1)
-                #    self._renderers[(None,None,None)]=ren
-                # else:
-                #    ren = self._renderers[(None,None,None)]
+                if tt.priority in self.text_renderers:
+                    ren = self.text_renderers[tt.priority]
+                else:
+                    ren = self.createRenderer()
+                    self.renWin.AddRenderer(ren)
+                    self.setLayer(ren, 1)
+
                 returned["vtk_backend_text_actors"] = vcs2vtk.genTextActor(
                     ren,
                     to=to,
                     tt=tt,
                     cmap=self.canvas.colormap)
                 self.setLayer(ren, tt.priority)
+                self.text_renderers[tt.priority] = ren
         elif gtype == "line":
             if gm.priority != 0:
                 actors = vcs2vtk.prepLine(self.renWin, gm,
@@ -551,7 +559,7 @@ class VTKVCSBackend(object):
                         wc=gm.worldcoordinate,
                         geo=geo,
                         priority=gm.priority,
-                        create_renderer=True)
+                        create_renderer=create_renderer)
                     create_renderer = False
                     if pd is None and act.GetUserTransform():
                         vcs2vtk.scaleMarkerGlyph(g, gs, pd, act)
@@ -1124,7 +1132,7 @@ class VTKVCSBackend(object):
         # Ok at this point this is all the info we need
         # we can determine if it's a unique renderer or not
         # let's see if we did this already.
-        if not create_renderer and\
+        if not create_renderer or\
                 (vp, wc_used, sc, priority) in self._renderers.keys():
             # yep already have one, we will use this Renderer
             Renderer, xScale, yScale = self._renderers[

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -328,10 +328,6 @@ class VTKVCSBackend(object):
             self.renWin.Render()
 
     def createRenderer(self, *args, **kargs):
-        """import inspect
-        c = inspect.currentframe()
-        caller = inspect.getouterframes(c)
-        print "createRenderer called by", caller[1][3], caller[1][2]"""
         # For now always use the canvas background
         ren = vtk.vtkRenderer()
         r, g, b = self.canvas.backgroundcolor

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -517,8 +517,9 @@ class VTKVCSBackend(object):
             returned.update(self.plot3D(data1, data2, tpl, gm, ren, **kargs))
         elif gtype in ["text"]:
             if tt.priority != 0:
-                if tt.priority in self.text_renderers:
-                    ren = self.text_renderers[tt.priority]
+                tt_key = (tt.priority, tuple(tt.viewport), tuple(tt.worldcoordinate), tt.projection)
+                if tt_key in self.text_renderers:
+                    ren = self.text_renderers[tt_key]
                 else:
                     ren = self.createRenderer()
                     self.renWin.AddRenderer(ren)
@@ -530,7 +531,7 @@ class VTKVCSBackend(object):
                     tt=tt,
                     cmap=self.canvas.colormap)
                 self.setLayer(ren, tt.priority)
-                self.text_renderers[tt.priority] = ren
+                self.text_renderers[tt_key] = ren
         elif gtype == "line":
             if gm.priority != 0:
                 actors = vcs2vtk.prepLine(self.renWin, gm,

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1129,7 +1129,7 @@ class VTKVCSBackend(object):
         # Ok at this point this is all the info we need
         # we can determine if it's a unique renderer or not
         # let's see if we did this already.
-        if not create_renderer or\
+        if not create_renderer and\
                 (vp, wc_used, sc, priority) in self._renderers.keys():
             # yep already have one, we will use this Renderer
             Renderer, xScale, yScale = self._renderers[

--- a/Packages/vcs/Lib/configurator.py
+++ b/Packages/vcs/Lib/configurator.py
@@ -674,6 +674,7 @@ class Configurator(object):
         if self.animation_timer is None:
             self.animation_timer = self.interactor.CreateRepeatingTimer(
                 self.animation_speed)
+            self.anim_button.set_state(1)
 
     def stop_animating(self):
         if self.animation_timer is not None:

--- a/Packages/vcs/Lib/configurator.py
+++ b/Packages/vcs/Lib/configurator.py
@@ -318,11 +318,18 @@ class Configurator(object):
                     for back_obj in back:
                         if type(back_obj) in (list, tuple):
                             for o in back_obj:
-                                if type(o) == vtk.vtkObject:
-                                    if o.IsA("vtkProp"):
-                                        actors.append(o)
-                        elif type(back_obj) == vtk.vtkObject and back_obj.IsA("vtkProp"):
-                            actors.append(back_obj)
+                                if o is not None:
+                                    try:
+                                        if o.IsA("vtkProp"):
+                                            actors.append(o)
+                                    except AttributeError:
+                                        continue
+                        else:
+                            try:
+                                if back_obj.IsA("vtkProp"):
+                                    actors.append(back_obj)
+                            except AttributeError:
+                                continue
 
         for ren in vtkIterate(self.render_window.GetRenderers()):
             keep_checking = False

--- a/Packages/vcs/Lib/vcs2vtk.py
+++ b/Packages/vcs/Lib/vcs2vtk.py
@@ -1169,29 +1169,30 @@ def prepFillarea(renWin, farea, cmap=None):
         color = [int((C / 100.) * 255) for C in cmap.index[c]]
         if len(farea.opacity) > i:
             opacity = farea.opacity[i] * 255 / 100.0
-        elif st == 'pattern':
-            opacity = 0
         else:
             opacity = 255
         # Draw colored background for solid or patterns
         # or white background for hatches
-        if st in ['solid', 'pattern']:
+        if st == 'solid':
             # Add the color to the color array:
             color = color + [int(opacity)]
             color_arr.SetTupleValue(cellId, color)
         else:
             color_arr.SetTupleValue(cellId, [255, 255, 255, 0])
 
-        if st in ['pattern', 'hatch']:
+        if st != "solid":
             # Patterns/hatches support
+            # We're switching patterns over to hatches that are black
+            if st == "pattern":
+                color = [0, 0, 0]
+            geo, proj_points = project(points, farea.projection, farea.worldcoordinate)
+            pd.SetPoints(proj_points)
             act = fillareautils.make_patterned_polydata(pd,
-                                                        st,
+                                                        "hatch",
                                                         idx,
                                                         color,
                                                         opacity)
             if act is not None:
-                geo, proj_points = project(points, farea.projection, farea.worldcoordinate)
-                pd.SetPoints(proj_points)
                 actors.append((act, geo))
 
     # Transform points

--- a/Packages/vcs/Lib/vcs2vtk.py
+++ b/Packages/vcs/Lib/vcs2vtk.py
@@ -1169,11 +1169,13 @@ def prepFillarea(renWin, farea, cmap=None):
         color = [int((C / 100.) * 255) for C in cmap.index[c]]
         if len(farea.opacity) > i:
             opacity = farea.opacity[i] * 255 / 100.0
+        elif st == "pattern":
+            opacity = 0
         else:
             opacity = 255
         # Draw colored background for solid or patterns
         # or white background for hatches
-        if st == 'solid':
+        if st in ('solid', "pattern"):
             # Add the color to the color array:
             color = color + [int(opacity)]
             color_arr.SetTupleValue(cellId, color)
@@ -1182,17 +1184,20 @@ def prepFillarea(renWin, farea, cmap=None):
 
         if st != "solid":
             # Patterns/hatches support
-            # We're switching patterns over to hatches that are black
-            if st == "pattern":
-                color = [0, 0, 0]
             geo, proj_points = project(points, farea.projection, farea.worldcoordinate)
             pd.SetPoints(proj_points)
             act = fillareautils.make_patterned_polydata(pd,
-                                                        "hatch",
+                                                        st,
                                                         idx,
                                                         color,
                                                         opacity)
             if act is not None:
+                if opacity > 0:
+                    m = vtk.vtkPolyDataMapper()
+                    m.SetInputData(pd)
+                    a = vtk.vtkActor()
+                    a.SetMapper(m)
+                    actors.append((a, geo))
                 actors.append((act, geo))
 
     # Transform points

--- a/Packages/vcs/Lib/vtk_ui/button.py
+++ b/Packages/vcs/Lib/vtk_ui/button.py
@@ -177,7 +177,9 @@ class Button(Widget):
             h_state = self.repr.GetHighlightState()
             self.repr.Highlight((h_state + 1) % 3)
             self.repr.Highlight(h_state)
-
+        else:
+            # Can't properly place if not showing, so let's save some cycles.
+            return
         text_width, text_height = self.text_widget.get_dimensions()
         swidth, sheight = self.interactor.GetRenderWindow().GetSize()
 

--- a/Packages/vcs/Lib/vtk_ui/manager.py
+++ b/Packages/vcs/Lib/vtk_ui/manager.py
@@ -25,6 +25,7 @@ class InterfaceManager(object):
 
         self.window.AddRenderer(self.renderer)
         self.window.AddRenderer(self.actor_renderer)
+        self.showing = True
 
         self.widgets = []
         self.timer_listener = self.interactor.AddObserver(
@@ -51,7 +52,7 @@ class InterfaceManager(object):
             return
         self.last_size = size
         for widget in self.widgets:
-            if widget.showing() == 1:
+            if widget.showing():
                 widget.place()
 
     def __render(self, obj, event):

--- a/Packages/vcs/Lib/vtk_ui/widget.py
+++ b/Packages/vcs/Lib/vtk_ui/widget.py
@@ -46,7 +46,7 @@ class Widget(object):
             del self.subscriptions[event]
 
     def showing(self):
-        return self.widget.GetEnabled() == 1
+        return self.widget.GetEnabled() == 1 and self.manager.showing
 
     def show(self):
         if not self.showing():

--- a/testing/vcs/test_vcs_gms_patterns_hatches.py
+++ b/testing/vcs/test_vcs_gms_patterns_hatches.py
@@ -80,7 +80,7 @@ xtra["squeeze"] = 1
 f = cdms2.open(os.path.join(vcs.sample_data, 'tas_ccsr-95a_1979.01-1979.12.nc'))
 s = f("tas", **xtra)
 f.close()
-
+gm.list()
 x.plot(s, gm, bg=bg)
 fnm = "test_vcs_%s_%s" % (args.gm.lower(), args.fill_style.lower())
 if args.projtype != "default":


### PR DESCRIPTION
This pull request addresses performance issues experienced in the VCS interactive features.

#### TL;DR

I made significant cuts to the number of renderers and actors (we now use fewer than in 2.2), but performance of prop picking is still worse than in 2.2. Need help getting it lower, @sankhesh @aashish24 @doutriaux1 @jbeezley.

## The Problem

The problem boils down to determining what exactly is under the mouse. To do that, I use VTK's `vtkPropPicker`, which, as far as I can tell, is the best tool for determining what actors are at a given (X, Y) coordinate. This object's `PickProp` method is called on every mouse move event and every mouse click event (this can be optimized out, since a mouse move will always happen before a mouse click, but is such a small fraction of the events triggering the `PickProp` that it's basically irrelevant).

The amount of time we spend hunting for actors has ballooned dramatically since 2.2; using methods detailed below, I discovered that the amount of time we spend in actor_at_point has nearly doubled. There are two main axes which we can adjust to effect the numbers on the profile; the number of renderers (each renderer has `PickProp` called on it separately) and the number of props. I discovered through experimentaiton the `PickProp`'s performance is linear with regards to the number of props, so reducing the number of renderers doesn't accomplish anything besides decreasing the total number of calls to `PickProp` (and maybe some fringe benefits with regards to render time that I haven't explored too much). That means that as far as I can tell, the only way to decrease the time spent picking is to reduce the total number of props in use. So, below is the detailed rundown of how I went about making some improvements to the performance of this function.


## Methodology

```
import vcs, cdms2

x = vcs.init()
try:
    f = cdms2.open(vcs.sample_data + '/clt.nc')
except AttributeError:
    # vcs.sample_data is new in 2.4
    f = cdms2.open(vcs.prefix + "/sample_data/clt.nc")
s = f('clt')

import cProfile
x.bgX = 1536
x.bgY = 1186
x.plot(s)
x.configure()
s = x.backend.renWin.GetSize()

p = cProfile.Profile()
p.enable()
for i in range(s[0]):
    x1, y1 = i, i % s[1]
    a = x.configurator.actor_at_point(x1, y1)
p.disable()
p.print_stats(sort="tottime")

```

This calls the relevant function (`actor_at_point`) a bunch of times, descending across to the right (wraps around eventually).

## 2.2.0 Profile

This release had quite tolerable performance. I'd say it's basically the goal.

Dividing `ncalls` of `PickProp` by `ncalls` of `actor_at_point`, we get 17 renderers in use.

ncalls  |  tottime  |  percall  |  cumtime  |  percall filename:lineno(function)
---|---|---|---|---
26112  |  72.052  |  0.003  |  72.211  |  0.003 {built-in method PickProp}
1536  |  0.264  |  0.000  |  72.720  |  0.047 configurator.py:275(actor_at_point)
30720  |  0.124  |  0.000  |  0.124  |  0.000 {built-in method GetNextItem}
52224  |  0.091  |  0.000  |  0.159  |  0.000 manager.py:38(__place)
52224  |  0.067  |  0.000  |  0.067  |  0.000 {built-in method GetSize}
29184  |  0.038  |  0.000  |  0.048  |  0.000 manager.py:144(get_manager)
30720  |  0.036  |  0.000  |  0.163  |  0.000 vcs2vtk.py:1466(vtkIterate)
29184  |  0.014  |  0.000  |  0.014  |  0.000 {built-in method GetLayer}
1536  |  0.013  |  0.000  |  0.013  |  0.000 {built-in method GetRenderers}
29184  |  0.010  |  0.000  |  0.010  |  0.000 {method 'get' of 'dict' objects}
1536  |  0.004  |  0.000  |  0.006  |  0.000 configurator.py:112(render_window)
1536  |  0.002  |  0.000  |  0.002  |  0.000 {built-in method InitTraversal}
1536  |  0.002  |  0.000  |  0.002  |  0.000 {built-in method GetRenderWindow}
815  |  0.002  |  0.000  |  0.002  |  0.000 {built-in method GetViewProp}
1  |  0.000  |  0.000  |  0.000  |  0.000 {range}
1  |  0.000  |  0.000  |  0.000  |  0.000 {method 'disable' of '_lsprof.Profiler' objects}

## 2.4-RC2 Profile

This is where we're at right now. It takes a smidge less than twice as long to do the same task, which is super annoying while you're mousing around. You'll notice that the `percall` time has increased, as well as the `ncalls` time. The reason `ncalls` has gone up is because we are operating with quite a lot more renderers, and we're picking across all of them. This means that the function `PickProp`, which has gotten slower since 2.2.0, will take longer and is called more. :disappointed: 

Dividing `ncalls` of `PickProp` by `ncalls` of `actor_at_point`, we get 23 renderers in use.

ncalls| tottime| percall| cumtime| percall filename:lineno(function)
---|---|---|---|---
35311| 129.447| 0.004| 129.673| 0.004 {built-in method PickProp}
1536| 0.335| 0.000| 130.356| 0.085 configurator.py:301(actor_at_point)
39936| 0.191| 0.000| 0.191| 0.000 {built-in method GetNextItem}
70622| 0.128| 0.000| 0.226| 0.000 manager.py:49(__place)
70622| 0.098| 0.000| 0.098| 0.000 {built-in method GetSize}
38400| 0.049| 0.000| 0.062| 0.000 manager.py:158(get_manager)
39936| 0.047| 0.000| 0.240| 0.000 vcs2vtk.py:1670(vtkIterate)
38400| 0.021| 0.000| 0.021| 0.000 {built-in method GetLayer}
1536| 0.014| 0.000| 0.014| 0.000 {built-in method GetRenderers}
38400| 0.013| 0.000| 0.013| 0.000 {method 'get' of 'dict' objects}
837| 0.004| 0.000| 0.004| 0.000 {built-in method GetViewProp}
1536| 0.004| 0.000| 0.006| 0.000 configurator.py:113(render_window)
1536| 0.002| 0.000| 0.002| 0.000 {built-in method InitTraversal}
1536| 0.002| 0.000| 0.002| 0.000 {built-in method GetRenderWindow}
1| 0.000| 0.000| 0.000| 0.000 {range}
1| 0.000| 0.000| 0.000| 0.000 {method 'disable' of '_lsprof.Profiler' objects}

## Reduced Renderers Profile

I started with the low-hanging fruit; I dramatically reduced the number of times we're going to call `PickProp` by reducing the number of renderers we're using. This dropped the `ncalls` to even lower than 2.2.0  :+1: , but it tripled the `percall` time :-1: ; looks like `PickProp` is roughly linear with the number of props. So, we're going to have to examine the use of props.

Dividing `ncalls` of `PickProp` by `ncalls` of `actor_at_point`, we get 8 renderers in use.

ncalls| tottime| percall| cumtime| percall filename:lineno(function)
---|---|---|---|---
12279|125.505|0.010|125.597|0.010 {built-in method PickProp}
1536|0.159|0.000|125.868|0.082 configurator.py:301(actor_at_point)
24558|0.054|0.000|0.092|0.000 manager.py:49(__place)
24558|0.038|0.000|0.038|0.000 {built-in method GetSize}
16896|0.023|0.000|0.046|0.000 vcs2vtk.py:1670(vtkIterate)
15360|0.022|0.000|0.029|0.000 manager.py:158(get_manager)
16896|0.021|0.000|0.021|0.000 {built-in method GetNextItem}
1536|0.017|0.000|0.017|0.000 {built-in method GetRenderers}
15360|0.010|0.000|0.010|0.000 {built-in method GetLayer}
15360|0.006|0.000|0.006|0.000 {method 'get' of 'dict' objects}
815|0.004|0.000|0.004|0.000 {built-in method GetViewProp}
1536|0.004|0.000|0.006|0.000 configurator.py:113(render_window)
1536|0.003|0.000|0.003|0.000 {built-in method InitTraversal}
1536|0.002|0.000|0.002|0.000 {built-in method GetRenderWindow}
1|0.000|0.000|0.000|0.000 {range}
1|0.000|0.000|0.000|0.000 {method 'disable' of '_lsprof.Profiler' objects}

## Prop Analysis

```
import vcs, cdms2

x = vcs.init()
try:
    f = cdms2.open(vcs.sample_data + '/clt.nc')
except AttributeError:
    f = cdms2.open(vcs.prefix + "/sample_data/clt.nc")
s = f('clt')

x.bgX = 1536
x.bgY = 1186
x.plot(s)

actors = []
rens = []
for ren in vcs.vcs2vtk.vtkIterate(x.backend.renWin.GetRenderers()):
    for act in vcs.vcs2vtk.vtkIterate(ren.GetActors()):
        actors.append(act)
    rens.append(ren)

print "# Actors:", len(actors)
print "# Renderers:", len(rens)
```

Version | Actor Count | Renderer Count
--- | --- | ---
2.2.0 | 62 | 17
2.4-RC2 | 286 | 23
Reduced Renderers | 286 | 8

Uh, wow. That's a big uptick in actors. Decided to double check my renderer count just in case the math was fuzzy above.

Alright, so where are those coming from? Guess it's time to dive into the types of actors in use...

There wasn't any easy way to gather this info externally, so I just added some print statements to every place I found that created a vtkActor() in the codebase and tallied them up afterwards.

### 2.2.0

Actor Source | Count
--- | ---
vcs2vtk.prepLine | **59**
vcs2vtk.prepFillarea | 1
VTKPlots.plot2D | 1
VTKPlots.plotContinents | 1

So, a lot of lines, and a few other things. Not too bad.

### 2.4-RC2

Actor Source | Count
--- | ---
vcs2vtk.prepLine | 59
vcs2vtk.prepFillarea | **225**
boxfillpipeline._plotInternal | 1
VTKPlots.plotContinents | 1

![Whoa](http://i.computer-bild.de/imgs/4/3/7/8/4/2/9/Conspiracy-Keanu-745x559-5176787edc95968f.jpg)

The code in `prepFillarea` was changed during the pattern/hatch PR to create a separate `vtkPolyData`/`vtkPolyDataMapper`/`vtkActor` per filled box, which is why we have so many actors. I cleaned that up a bit (now will only make one for each patterned fill and one that does all of the "solid" fills). This brought our actor count back down to where it was for 2.2, but, sadly, the performance gains did not keep pace.

### Reduced Renderers + FillArea Refactor Actor Counts

Actor Source | Count
--- | ---
vcs2vtk.prepLine | 59
vcs2vtk.prepFillarea | 1
boxfillpipeline._plotInternal | 1
VTKPlots.plotContinents | 1

### Reduced Renderers + FillArea Refactor Profile

ncalls | tottime | percall | cumtime | percall filename:lineno(function)
---|---|---|---|---
12279 | 106.924 | 0.009 | 107.009 | 0.009 {built-in method PickProp}
1536 | 0.157 | 0.000 | 107.275 | 0.070 configurator.py:301(actor_at_point)
24558 | 0.050 | 0.000 | 0.085 | 0.000 manager.py:49(__place)
24558 | 0.035 | 0.000 | 0.035 | 0.000 {built-in method GetSize}
15360 | 0.023 | 0.000 | 0.029 | 0.000 manager.py:158(get_manager)
16896 | 0.023 | 0.000 | 0.045 | 0.000 vcs2vtk.py:1687(vtkIterate)
16896 | 0.019 | 0.000 | 0.019 | 0.000 {built-in method GetNextItem}
1536 | 0.016 | 0.000 | 0.016 | 0.000 {built-in method GetRenderers}
15360 | 0.009 | 0.000 | 0.009 | 0.000 {built-in method GetLayer}
15360 | 0.006 | 0.000 | 0.006 | 0.000 {method 'get' of 'dict' objects}
1536 | 0.004 | 0.000 | 0.006 | 0.000 configurator.py:113(render_window)
815 | 0.004 | 0.000 | 0.004 | 0.000 {built-in method GetViewProp}
1536 | 0.003 | 0.000 | 0.003 | 0.000 {built-in method InitTraversal}
1536 | 0.003 | 0.000 | 0.003 | 0.000 {built-in method GetRenderWindow}
1 | 0.000 | 0.000 | 0.000 | 0.000 {range}
1 | 0.000 | 0.000 | 0.000 | 0.000 {method 'disable' of '_lsprof.Profiler' objects}

Alright, we shaved 25 seconds off of the execution time of the test, and .001 seconds off the `percall` time. That is still a pretty sizable gap between here and 2.2 performance, though...

## Line Polydata Optimization

So, let's start getting wild and crazy and actually try and be better behaved than 2.2. 59 lines is a lot of actors/polydata. How about we combine a few of those? As is, every single line that is drawn on screen gets its own actor/polydata pipeline. I merged them down so that each vcs Line that is passed in will only generate one actor per line width and line pattern (since those are set on the actor itself). In practice, this pretty much means one actor per vcs Line object plotted.

This shaves another 11 seconds off of the testcase.

### Line Polydata Optimization Actor Counts

Actor Source | Count
--- | ---
vcs2vtk.prepLine | 6
vcs2vtk.prepFillarea | 1
boxfillpipeline._plotInternal | 1
VTKPlots.plotContinents | 1


### Line Polydata + Reduced Renderers + Fillarea Polydata Profile

ncalls | tottime | percall | cumtime | percall filename:lineno(function)
---|---|---|---|---
12279|95.333|0.008|95.415|0.008 {built-in method PickProp}
1536|0.150|0.000|95.668|0.062 configurator.py:301(actor_at_point)
24558|0.048|0.000|0.082|0.000 manager.py:49(__place)
24558|0.034|0.000|0.034|0.000 {built-in method GetSize}
15360|0.021|0.000|0.027|0.000 manager.py:158(get_manager)
16896|0.019|0.000|0.040|0.000 vcs2vtk.py:1711(vtkIterate)
1536|0.018|0.000|0.018|0.000 {built-in method GetRenderers}
16896|0.017|0.000|0.017|0.000 {built-in method GetNextItem}
15360|0.008|0.000|0.008|0.000 {built-in method GetLayer}
15360|0.006|0.000|0.006|0.000 {method 'get' of 'dict' objects}
1536|0.004|0.000|0.006|0.000 configurator.py:113(render_window)
815|0.004|0.000|0.004|0.000 {built-in method GetViewProp}
1536|0.003|0.000|0.003|0.000 {built-in method InitTraversal}
1536|0.002|0.000|0.002|0.000 {built-in method GetRenderWindow}
1|0.000|0.000|0.000|0.000 {range}
1|0.000|0.000|0.000|0.000 {method 'disable' of '_lsprof.Profiler' objects}

So now I've reduced the number of actors to as few as possible, reduced the number of renderers to as few as possible, and performance is still worse than it was (and at this point I would expect it to be better). I'm not sure where to go from here to get those last 20 seconds of execution time back, so I'm opening it up to suggestions.