### PR TITLE
Do not wrap again in update_input

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1294,6 +1294,10 @@ class VTKVCSBackend(object):
                 vg.GetPointData().AddArray(w)
                 ports[0].SetInputData(vg)
 
+            projection = None
+            if "vtk_backend_geo" in vtkobjects:
+                projection = vtkobjects["vtk_backend_geo"]
+
             if "vtk_backend_actors" in vtkobjects:
                 i = 0
                 for a in vtkobjects["vtk_backend_actors"]:
@@ -1340,8 +1344,9 @@ class VTKVCSBackend(object):
                                 mapper.SetScalarModeToUseCellData()
                             mapper.SetScalarRange(rg[0], rg[1])
                     act.SetMapper(mapper)
-                    act = vcs2vtk.doWrap(a[0], wrp)
-                    a[0].SetMapper(act.GetMapper())
+                    if not projection:
+                        # Wrap only if the data is not projected
+                        act = vcs2vtk.doWrap(a[0], wrp)
                     i += 1
 
         taxis = array1.getTime()

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -652,6 +652,18 @@ cdat_add_test(vcs_test_taylor_2_quads
       ENDFOREACH(style)
     ENDFOREACH(gm)
 
+    FOREACH(gm isofill meshfill boxfill)
+      FOREACH(proj polar robinson mercator mollweide lambert)
+        cdat_add_test(vcs_test_animate_projected_${gm}_${proj}
+          "${PYTHON_EXECUTABLE}"
+          "${cdat_SOURCE_DIR}/testing/vcs/test_vcs_gms_animate_projected_plots.py"
+          --gm_type=${gm}
+          --projection_type=${proj}
+          --source_dir=${BASELINE_DIR}
+          )
+      ENDFOREACH(proj)
+    ENDFOREACH(gm)
+
     FOREACH(flip None X XY Y)
       cdat_add_test(vcs_test_flip${flip}
         "${PYTHON_EXECUTABLE}"

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -660,6 +660,7 @@ cdat_add_test(vcs_test_taylor_2_quads
           --gm_type=${gm}
           --projection_type=${proj}
           --source_dir=${BASELINE_DIR}
+          --threshold=40
           )
       ENDFOREACH(proj)
     ENDFOREACH(gm)

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -659,7 +659,7 @@ cdat_add_test(vcs_test_taylor_2_quads
           "${cdat_SOURCE_DIR}/testing/vcs/test_vcs_gms_animate_projected_plots.py"
           --gm_type=${gm}
           --projection_type=${proj}
-          --source_dir=${BASELINE_DIR}
+          --source=${BASELINE_DIR}/test_vcs_animate_projected_${gm}_${proj}.png
           --threshold=40
           )
       ENDFOREACH(proj)

--- a/testing/vcs/test_vcs_gms_animate_projected_plots.py
+++ b/testing/vcs/test_vcs_gms_animate_projected_plots.py
@@ -1,0 +1,81 @@
+# Test animation of projected plots
+
+import argparse
+import cdms2
+import MV2
+import os
+import sys
+import vcs
+
+pth = os.path.join(os.path.dirname(__file__), "..")
+sys.path.append(pth)
+import checkimage  # noqa
+
+p = argparse.ArgumentParser(description="Testing animation of projected plots")
+p.add_argument("--gm_type", dest="gm", help="gm to test")
+p.add_argument("--projection_type", dest="projtype", default="default",
+               help="use a specific projection type")
+p.add_argument("--source_dir", dest="src", help="baseline directory")
+p.add_argument("--keep", dest="keep", action="store_true", default=False,
+               help="Save images, even if baseline matches.")
+p.add_argument("--threshold", dest="threshold", type=int,
+               default=checkimage.defaultThreshold,
+               help="Threshold value for image differnces")
+
+args = p.parse_args(sys.argv[1:])
+
+gm_type = args.gm
+
+x = vcs.init()
+x.setantialiasing(0)
+x.drawlogooff()
+x.setbgoutputdimensions(1200, 1091, units="pixels")
+
+s = None
+
+if gm_type == "meshfill":
+    f = cdms2.open(os.path.join(vcs.sample_data, "sampleCurveGrid4.nc"))
+    s2 = f("sample")
+
+    s = MV2.resize(s2, (4, 32, 48))
+    t = cdms2.createAxis(range(4))
+    t.units = "months since 2015"
+    t.id = "time"
+    t.designateTime()
+    s.setAxis(0, t)
+    s.setAxis(1, s2.getAxis(0))
+    s.setAxis(2, s2.getAxis(1))
+    s.setGrid(s2.getGrid())
+    for i in range(4):
+        s[i] = s[i] * (1 + float(i)/10.)
+else:
+    f = cdms2.open(os.path.join(vcs.sample_data, "clt.nc"))
+    s = f("clt", slice(0, 12))  # read only 12 times steps to speed up things
+
+gm = vcs.creategraphicsmethod(gm_type, "default")
+if args.projtype != "default":
+    p = vcs.createprojection()
+    try:
+        ptype = int(args.projtype)
+    except:
+        ptype = args.projtype
+    p.type = ptype
+    gm.projection = p
+
+x.plot(s, gm, bg=1)
+x.animate.create()
+
+prefix = "test_vcs_animate_%s_%s" % (gm_type.lower(), args.projtype.lower())
+x.animate.save("%s.mp4" % prefix)
+pngs = x.animate.close(preserve_pngs=True)  # so we can look at them again
+
+baseline_pth = os.path.join(args.src, prefix)
+ret = 0
+for p in pngs:
+    ret += checkimage.check_result_image(p, os.path.join(baseline_pth,
+                                         os.path.split(p)[1]),
+                                         args.threshold)
+if ret == 0 and not args.keep:
+    os.removedirs(os.path.split(p)[0])
+    os.remove("%s.mp4" % prefix)
+sys.exit(ret)

--- a/testing/vcs/test_vcs_gms_animate_projected_plots.py
+++ b/testing/vcs/test_vcs_gms_animate_projected_plots.py
@@ -70,11 +70,13 @@ x.animate.save("%s.mp4" % prefix)
 pngs = x.animate.close(preserve_pngs=True)  # so we can look at them again
 
 ret = 0
-p = pngs[-1]
+pdir = os.path.split(pngs[0])[0]
+p = pdir + os.sep + "anim_0.png"
 ret = checkimage.check_result_image(p, args.src, args.threshold)
 if ret == 0 and not args.keep:
-    for f in pngs[0:len(pngs) - 1]:
-        os.remove(f)
-    os.removedirs(os.path.split(p)[0])
+    for f in pngs:
+        if os.path.isfile(f):
+            os.remove(f)
+    os.removedirs(pdir)
     os.remove("%s.mp4" % prefix)
 sys.exit(ret)

--- a/testing/vcs/test_vcs_gms_animate_projected_plots.py
+++ b/testing/vcs/test_vcs_gms_animate_projected_plots.py
@@ -15,7 +15,7 @@ p = argparse.ArgumentParser(description="Testing animation of projected plots")
 p.add_argument("--gm_type", dest="gm", help="gm to test")
 p.add_argument("--projection_type", dest="projtype", default="default",
                help="use a specific projection type")
-p.add_argument("--source_dir", dest="src", help="baseline directory")
+p.add_argument("--source", dest="src", help="path to baseline image")
 p.add_argument("--keep", dest="keep", action="store_true", default=False,
                help="Save images, even if baseline matches.")
 p.add_argument("--threshold", dest="threshold", type=int,
@@ -69,12 +69,9 @@ prefix = "test_vcs_animate_%s_%s" % (gm_type.lower(), args.projtype.lower())
 x.animate.save("%s.mp4" % prefix)
 pngs = x.animate.close(preserve_pngs=True)  # so we can look at them again
 
-baseline_pth = os.path.join(args.src, prefix)
 ret = 0
 p = pngs[-1]
-ret = checkimage.check_result_image(p, os.path.join(baseline_pth,
-                                    os.path.split(p)[1]),
-                                    args.threshold)
+ret = checkimage.check_result_image(p, args.src, args.threshold)
 if ret == 0 and not args.keep:
     for f in pngs[0:len(pngs) - 1]:
         os.remove(f)

--- a/testing/vcs/test_vcs_gms_animate_projected_plots.py
+++ b/testing/vcs/test_vcs_gms_animate_projected_plots.py
@@ -71,11 +71,13 @@ pngs = x.animate.close(preserve_pngs=True)  # so we can look at them again
 
 baseline_pth = os.path.join(args.src, prefix)
 ret = 0
-for p in pngs:
-    ret += checkimage.check_result_image(p, os.path.join(baseline_pth,
-                                         os.path.split(p)[1]),
-                                         args.threshold)
+p = pngs[-1]
+ret = checkimage.check_result_image(p, os.path.join(baseline_pth,
+                                    os.path.split(p)[1]),
+                                    args.threshold)
 if ret == 0 and not args.keep:
+    for f in pngs[0:len(pngs) - 1]:
+        os.remove(f)
     os.removedirs(os.path.split(p)[0])
     os.remove("%s.mp4" % prefix)
 sys.exit(ret)


### PR DESCRIPTION
This change fixes the issue wherein no output was being produced
when animating projected data. Each draw_frame call invokes
VTKPlots::update_input which in turn calls doWrap on the
actor. Trying to wrap projected data fails.

Fixes #1086