### PR TITLE
Stop configuring if test data fails to download

### DIFF
--- a/CMake/cdat_modules/uvcmetrics_external.cmake
+++ b/CMake/cdat_modules/uvcmetrics_external.cmake
@@ -13,7 +13,8 @@ if (CDAT_DOWNLOAD_UVCMETRICS_TESTDATA)
     )
 
   if (NOT ${res} EQUAL 0)
-    message("[INFO] Failed to fetch test data for uvcmetrics, tests will fail")
+    message(WARNING "${ver}")
+    message(FATAL_ERROR "Failed to fetch test data for uvcmetrics, tests will fail")
   endif()
 endif()
 

--- a/CMake/cdat_modules/uvcmetrics_external.cmake
+++ b/CMake/cdat_modules/uvcmetrics_external.cmake
@@ -5,6 +5,8 @@ if (CDAT_DOWNLOAD_UVCMETRICS_TESTDATA)
     ${cdat_CMAKE_BINARY_DIR}/fetch_uvcmetrics_testdata.py
     @ONLY)
 
+  message(INFO "Running \"${PYTHON_EXECUTABLE} ${cdat_CMAKE_BINARY_DIR}/fetch_uvcmetrics_testdata.py\"")
+  message(INFO "in \"${cdat_CMAKE_SOURCE_DIR}\"")
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} ${cdat_CMAKE_BINARY_DIR}/fetch_uvcmetrics_testdata.py
     WORKING_DIRECTORY ${cdat_CMAKE_SOURCE_DIR}

--- a/CMake/cdat_modules/uvcmetrics_external.cmake
+++ b/CMake/cdat_modules/uvcmetrics_external.cmake
@@ -7,7 +7,7 @@ if (CDAT_DOWNLOAD_UVCMETRICS_TESTDATA)
 
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} ${cdat_CMAKE_BINARY_DIR}/fetch_uvcmetrics_testdata.py
-    WORKING_DIRECTORY ${cdat_SOURCE_DIR}
+    WORKING_DIRECTORY ${cdat_CMAKE_SOURCE_DIR}
     RESULT_VARIABLE res
     OUTPUT_VARIABLE ver
     )


### PR DESCRIPTION
This is mostly just to see what is going on with the dashboard machines, but we really should treat this as a fatal error.