### PR TITLE
ENH: Add the ability to write/read PNG metadata

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -1024,6 +1024,10 @@ class VTKVCSBackend(object):
         writer = vtk.vtkPNGWriter()
         writer.SetInputConnection(imgfiltr.GetOutputPort())
         writer.SetFileName(file)
+        # add text chunks to the writer
+        m = args.get('metadata', {})
+        for k, v in m.iteritems():
+            writer.AddText(k, v)
         writer.Write()
 
     def cgm(self, file):

--- a/Packages/vcs/Lib/utils.py
+++ b/Packages/vcs/Lib/utils.py
@@ -23,6 +23,7 @@ import tempfile
 import vcsaddons
 import cdms2
 import genutil
+import vtk
 
 indent = 1
 sort_keys = True
@@ -1702,3 +1703,14 @@ def getworldcoordinates(gm, X, Y):
         wc[0] -= .0001
         wc[1] += .0001
     return wc
+
+
+def png_read_metadata(path):
+    reader = vtk.vtkPNGReader()
+    reader.SetFileName(path)
+    reader.Update()
+    numberOfTextChunks = reader.GetNumberOfTextChunks()
+    m = {}
+    for i in range(0, numberOfTextChunks):
+        m[reader.GetTextKey(i)] = reader.GetTextValue(i)
+    return m

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -23,6 +23,10 @@ cdat_add_test(vcs_test_png_set_size
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_png_set_size.py
 )
+cdat_add_test(vcs_test_png_metadata
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_png_metadata.py
+)
 cdat_add_test(vcs_test_text_object_as_input.py
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_text_object_as_input.py

--- a/testing/vcs/test_png_metadata.py
+++ b/testing/vcs/test_png_metadata.py
@@ -1,0 +1,14 @@
+# Check if text chunks are saved correctly in a PNG file
+import vcs
+
+x=vcs.init()
+x.drawlogooff()
+x.setantialiasing(0)
+
+x.plot([1,2,3,4,5,4,3,2,1],bg=1)
+
+fnm = "test_png_metadata.png"
+m = {'one':'value one','two':'value two'}
+x.png(fnm, width=15, metadata=m)
+assert(vcs.png_read_metadata(fnm) == m)
+


### PR DESCRIPTION
Canvas.png now has an extra parameter 'metadata' which is
a dictionary with key,value pairs to be written to the PNG file.
We added a new function vcs.png_read_metadata which returns
a dictionary of key,value pairs read from the PNG file.