### PR TITLE
Fixed cmake warning during configure step

### DIFF
--- a/CMake/cdat_modules/ffmpeg_external.cmake
+++ b/CMake/cdat_modules/ffmpeg_external.cmake
@@ -6,9 +6,9 @@ set(ENV{PATH} $ENV{PATH}:${cdat_EXTERNALS}/bin)
 find_program(YASM_BIN "yasm")
 
 if (NOT YASM_BIN)
-  set(ffmpeg_conf_args --disable-yasm^^--enable-gpl^^--enable-libx264^^--extra-cxxflags=@ffmpeg_source@^^--enable-shared^^--enable-zlib)
+  set(ffmpeg_conf_args --disable-yasm^^--enable-gpl^^--enable-libx264^^--extra-cxxflags=${ffmpeg_source}^^--enable-shared^^--enable-zlib)
 else()
-  set(ffmpeg_conf_args --enable-gpl^^--enable-libx264^^--extra-cxxflags=@ffmpeg_source@^^--enable-shared^^--enable-zlib)
+  set(ffmpeg_conf_args --enable-gpl^^--enable-libx264^^--extra-cxxflags=${ffmpeg_source}^^--enable-shared^^--enable-zlib)
 endif()
 
 ExternalProject_Add(FFMPEG


### PR DESCRIPTION
Use of @var@ is not a cmake standard unless a cmake
configure is called on the document.