### PR TITLE
Now will work if there is no .uvcdat directory

### DIFF
--- a/CMake/cdat_modules_extra/uvcdat.in
+++ b/CMake/cdat_modules_extra/uvcdat.in
@@ -50,6 +50,13 @@ if [ $redirect = false ]  ;then
 else
     # Replace all uses of ~ with $HOME
     target="${target/#\~/$HOME}"
+
+    # Check if path exists
+    target_dir="$(dirname $target)"
+    if [ ! -d "$target_dir" ] ;then
+        mkdir -p $target_dir
+    fi
+
     # Make sure the file exists and that we have write privileges
     touch $target
     # Launch with redirection


### PR DESCRIPTION
Fixes a bug where the `uvcdat` launcher script would crash if there was no .uvcdat directory (or if the user specified a path pointing at a directory that doesn't exist for output).