### PR TITLE
BUG #1645: Blank spots on solid fillareastyle with fillareaindices

### DIFF
--- a/Packages/vcs/Lib/vcsvtk/boxfillpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/boxfillpipeline.py
@@ -346,7 +346,7 @@ class BoxfillPipeline(Pipeline2D):
         geos = []
         wholeDataMin, wholeDataMax = vcs.minmax(self._originalData1)
         _colorMap = self.getColorMap()
-
+        assert(style != 'solid' or len(tmpLevels) == 1)
         for i, l in enumerate(tmpLevels):
             # Ok here we are trying to group together levels can be, a join
             # will happen if: next set of levels continues where one left off
@@ -368,11 +368,11 @@ class BoxfillPipeline(Pipeline2D):
                 lut.SetNumberOfTableValues(1)
                 r, g, b, a = self.getColorIndexOrRGBA(_colorMap, color)
                 if style == 'solid':
-                    tmpOpacity = tmpOpacities[i]
+                    tmpOpacity = tmpOpacities[j]
                     if tmpOpacity is None:
                         tmpOpacity = a / 100.
                     else:
-                        tmpOpacity = tmpOpacities[i] / 100.
+                        tmpOpacity = tmpOpacities[j] / 100.
                     lut.SetTableValue(0, r / 100., g / 100., b / 100., tmpOpacity)
                 else:
                     lut.SetTableValue(0, 1., 1., 1., 0.)

--- a/Packages/vcs/Lib/vcsvtk/isofillpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/isofillpipeline.py
@@ -102,6 +102,7 @@ class IsofillPipeline(Pipeline2D):
         x1, x2, y1, y2 = vcs.utils.getworldcoordinates(self._gm,
                                                        self._data1.getAxis(-1),
                                                        self._data1.getAxis(-2))
+        assert(style != 'solid' or len(tmpLevels) == 1)
         for i, l in enumerate(tmpLevels):
             # Ok here we are trying to group together levels can be, a join
             # will happen if: next set of levels continues where one left off
@@ -123,11 +124,11 @@ class IsofillPipeline(Pipeline2D):
             for j, color in enumerate(tmpColors[i]):
                 r, g, b, a = self.getColorIndexOrRGBA(_colorMap, color)
                 if style == 'solid':
-                    tmpOpacity = tmpOpacities[i]
+                    tmpOpacity = tmpOpacities[j]
                     if tmpOpacity is None:
                         tmpOpacity = a / 100.
                     else:
-                        tmpOpacity = tmpOpacities[i] / 100.
+                        tmpOpacity = tmpOpacities[j] / 100.
                     lut.SetTableValue(j, r / 100., g / 100., b / 100., tmpOpacity)
                 else:
                     lut.SetTableValue(j, 1., 1., 1., 0.)

--- a/Packages/vcs/Lib/vcsvtk/meshfillpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/meshfillpipeline.py
@@ -94,6 +94,7 @@ class MeshfillPipeline(Pipeline2D):
                                           self._vtkDataSetBounds[3])
         _colorMap = self.getColorMap()
         self._patternActors = []
+        assert(style != 'solid' or len(tmpLevels) == 1)
         for i, l in enumerate(tmpLevels):
             # Ok here we are trying to group together levels can be, a join
             # will happen if: next set of levels contnues where one left off
@@ -115,11 +116,11 @@ class MeshfillPipeline(Pipeline2D):
                 lut.SetNumberOfTableValues(1)
                 r, g, b, a = self.getColorIndexOrRGBA(_colorMap, color)
                 if style == 'solid':
-                    tmpOpacity = tmpOpacities[i]
+                    tmpOpacity = tmpOpacities[j]
                     if tmpOpacity is None:
                         tmpOpacity = a / 100.
                     else:
-                        tmpOpacity = tmpOpacities[i] / 100.
+                        tmpOpacity = tmpOpacities[j] / 100.
                     lut.SetTableValue(
                         0, r / 100., g / 100., b / 100., tmpOpacity)
                 else:

--- a/Packages/vcs/Lib/vcsvtk/pipeline2d.py
+++ b/Packages/vcs/Lib/vcsvtk/pipeline2d.py
@@ -183,15 +183,18 @@ class Pipeline2D(IPipeline2D):
                 I = indices[i]
                 O = opacities[i]
             else:
-                if l[0] == L[-1] and I == indices[i] and\
+                if l[0] == L[-1] and\
                         ((style == 'solid') or
-                            (C[-1] == self._contourColors[i] and O == opacities[i])):
+                            (I == indices[i] and C[-1] == self._contourColors[i] and
+                             O == opacities[i])):
                     # Ok same type lets keep going
                     if numpy.allclose(l[1], 1.e20):
                         L.append(self._scalarRange[1] + 1.)
                     else:
                         L.append(l[1])
                     C.append(self._contourColors[i])
+                    tmpOpacities.append(O)
+                    O = opacities[i]
                 else:  # ok we need new contouring
                     tmpLevels.append(L)
                     tmpColors.append(C)

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -685,7 +685,7 @@ cdat_add_test(vcs_test_taylor_2_quads
       ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_hatches_patterns.py
       "${BASELINE_DIR}/test_vcs_hatches_patterns.png"
       )
-    FOREACH(gm isofill boxfill)
+    FOREACH(gm isofill boxfill meshfill)
       FOREACH(style solid pattern hatch)
         cdat_add_test(vcs_test_${gm}_${style}_fill
           "${PYTHON_EXECUTABLE}"
@@ -693,7 +693,7 @@ cdat_add_test(vcs_test_taylor_2_quads
           --gm_type=${gm}
           --fill_style=${style}
           "--source=${BASELINE_DIR}/test_vcs_${gm}_${style}_SH_-180_180.png"
-          "--threshold=15"
+          "--threshold=25"
           )
         cdat_add_test(vcs_test_${gm}_${style}_fill_0_360
           "${PYTHON_EXECUTABLE}"
@@ -703,7 +703,7 @@ cdat_add_test(vcs_test_taylor_2_quads
           --lon1=0
           --lon2=360
           "--source=${BASELINE_DIR}/test_vcs_${gm}_${style}_SH_0_360.png"
-          "--threshold=15"
+          "--threshold=25"
           )
       ENDFOREACH(style)
     ENDFOREACH(gm)

--- a/testing/vcs/test_vcs_gms_patterns_hatches.py
+++ b/testing/vcs/test_vcs_gms_patterns_hatches.py
@@ -59,6 +59,9 @@ else:
 if args.gm == "boxfill":
     gm.boxfill_type = "custom"
 
+if args.gm == "meshfill":
+    gm.mesh = True
+
 nm_xtra = ""
 xtra = {}
 if args.lat1 != args.lat2:


### PR DESCRIPTION
The solid fillareastyle was treated as a pattern style in that
each level was extracted and rendered individually. Because of a
bug in vtkBandedPolyDataContourFilter lower isocontours differ
from upper isocontours which results in blank spots. In this fix
we trigger merging of levels which fixes the problem for solid fill.
We'll fix the problem for pattern fill in a subsequent commit.