### PR TITLE
Made colormaps skip default indices

### DIFF
--- a/Packages/vcs/Lib/colors.py
+++ b/Packages/vcs/Lib/colors.py
@@ -28,7 +28,7 @@ def matplotlib2vcs(cmap, vcs_name=None):
             (vcs_name, vcs_name_final))
     vcs_cmap = vcs.createcolormap(vcs_name_final)
     cmap_rgbs = cmap(range(0, cmap.N))
-    for i in range(5, 256):
-        vcs_cmap.setcolorcell(i, *([int(x * 100) for x in cmap_rgbs[(i - 5) % cmap.N][:4]]))
+    for i in range(5, min(cmap.N, 256)):
+        vcs_cmap.setcolorcell(i, *([int(x * 100) for x in cmap_rgbs[(i - 5)][:4]]))
 
     return vcs_cmap

--- a/Packages/vcs/Lib/colors.py
+++ b/Packages/vcs/Lib/colors.py
@@ -28,7 +28,7 @@ def matplotlib2vcs(cmap, vcs_name=None):
             (vcs_name, vcs_name_final))
     vcs_cmap = vcs.createcolormap(vcs_name_final)
     cmap_rgbs = cmap(range(0, cmap.N))
-    for i in range(0, min(cmap.N, 256)):
-        vcs_cmap.setcolorcell(i, *([int(x * 100) for x in cmap_rgbs[i][:4]]))
+    for i in range(5, 256):
+        vcs_cmap.setcolorcell(i, *([int(x * 100) for x in cmap_rgbs[(i - 5) % cmap.N][:4]]))
 
     return vcs_cmap


### PR DESCRIPTION
@doutriaux1 Sorry, I lied. Found one more thing.

Matplotlib colormaps don't start with black like ours do; so let's skip 1-5.

```
import vcs, cdms2, os

cltfile = cdms2.open(os.path.join(vcs.sample_data, "clt.nc"))
clt = cltfile("clt")

canvas = vcs.init()

colormap = vcs.matplotlib2vcs("Blues")
canvas.setcolormap(colormap)
canvas.plot(clt)
canvas.png("matplotlib_colormaps")
```
results in 
![matplotlib_colormaps](https://cloud.githubusercontent.com/assets/718512/11518283/da48288c-9844-11e5-876f-3699865a58e9.png)

This should now be fixed.