### PR TITLE
BUG #1739: fitToViewport uses dataset bounds instead of recomputing them

### DIFF
--- a/Packages/vcs/Lib/vcsvtk/boxfillpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/boxfillpipeline.py
@@ -169,10 +169,11 @@ class BoxfillPipeline(Pipeline2D):
 
             # create a new renderer for this mapper
             # (we need one for each mapper because of camera flips)
-            self._context().fitToViewport(
+            self._context().fitToViewportBounds(
                 act, [self._template.data.x1, self._template.data.x2,
                       self._template.data.y1, self._template.data.y2],
-                wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
 
@@ -180,10 +181,11 @@ class BoxfillPipeline(Pipeline2D):
             if self._vtkGeoTransform is None:
                 # If using geofilter on wireframed does not get wrapped not sure
                 # why so sticking to many mappers
-                self._context().fitToViewport(
+                self._context().fitToViewportBounds(
                     act, [self._template.data.x1, self._template.data.x2,
                           self._template.data.y1, self._template.data.y2],
-                    wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                    wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                    geo=self._vtkGeoTransform,
                     priority=self._template.data.priority,
                     create_renderer=True)
                 actors.append([act, [x1, x2, y1, y2]])
@@ -197,7 +199,8 @@ class BoxfillPipeline(Pipeline2D):
             z = None
         self._resultDict.update(self._context().renderTemplate(self._template,
                                                                self._data1,
-                                                               self._gm, t, z))
+                                                               self._gm, t, z,
+                                                               vtk_backend_grid=self._vtkDataSet))
 
         if getattr(self._gm, "legend", None) is not None:
             self._contourLabels = self._gm.legend
@@ -244,7 +247,8 @@ class BoxfillPipeline(Pipeline2D):
             projection = vcs.elements["projection"][self._gm.projection]
             self._context().plotContinents(x1, x2, y1, y2, projection,
                                            self._dataWrapModulo,
-                                           self._template)
+                                           self._template,
+                                           vtk_backend_grid=self._vtkDataSet)
 
     def _plotInternalBoxfill(self):
         """Implements the logic to render a non-custom boxfill."""

--- a/Packages/vcs/Lib/vcsvtk/isofillpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/isofillpipeline.py
@@ -177,18 +177,20 @@ class IsofillPipeline(Pipeline2D):
 
             # create a new renderer for this mapper
             # (we need one for each mapper because of cmaera flips)
-            self._context().fitToViewport(
+            self._context().fitToViewportBounds(
                 act, [self._template.data.x1, self._template.data.x2,
                       self._template.data.y1, self._template.data.y2],
-                wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
 
         for act in patternActors:
-            self._context().fitToViewport(
+            self._context().fitToViewportBounds(
                 act, [self._template.data.x1, self._template.data.x2,
                       self._template.data.y1, self._template.data.y2],
-                wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
             actors.append([act, [x1, x2, y1, y2]])
@@ -203,7 +205,8 @@ class IsofillPipeline(Pipeline2D):
 
         self._resultDict.update(self._context().renderTemplate(self._template,
                                                                self._data1,
-                                                               self._gm, t, z))
+                                                               self._gm, t, z,
+                                                               vtk_backend_grid=self._vtkDataSet))
 
         legend = getattr(self._gm, "legend", None)
 
@@ -242,4 +245,5 @@ class IsofillPipeline(Pipeline2D):
             projection = vcs.elements["projection"][self._gm.projection]
             self._context().plotContinents(x1, x2, y1, y2, projection,
                                            self._dataWrapModulo,
-                                           self._template)
+                                           self._template,
+                                           vtk_backend_grid=self._vtkDataSet)

--- a/Packages/vcs/Lib/vcsvtk/isolinepipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/isolinepipeline.py
@@ -288,10 +288,11 @@ class IsolinePipeline(Pipeline2D):
 
             # create a new renderer for this mapper
             # (we need one for each mapper because of cmaera flips)
-            self._context().fitToViewport(
+            self._context().fitToViewportBounds(
                 act, [self._template.data.x1, self._template.data.x2,
                       self._template.data.y1, self._template.data.y2],
-                wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
 
@@ -320,10 +321,11 @@ class IsolinePipeline(Pipeline2D):
             actors.append([act, self._maskedDataMapper, [x1, x2, y1, y2]])
             # create a new renderer for this mapper
             # (we need one for each mapper because of cmaera flips)
-            self._context().fitToViewport(
+            self._context().fitToViewportBounds(
                 act, [self._template.data.x1, self._template.data.x2,
                       self._template.data.y1, self._template.data.y2],
-                wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
 
@@ -337,7 +339,8 @@ class IsolinePipeline(Pipeline2D):
 
         self._resultDict.update(self._context().renderTemplate(self._template,
                                                                self._data1,
-                                                               self._gm, t, z))
+                                                               self._gm, t, z,
+                                                               vtk_backend_grid=self._vtkDataSet))
 
         if self._context().canvas._continents is None:
             self._useContinents = False
@@ -345,4 +348,5 @@ class IsolinePipeline(Pipeline2D):
             projection = vcs.elements["projection"][self._gm.projection]
             self._context().plotContinents(x1, x2, y1, y2, projection,
                                            self._dataWrapModulo,
-                                           self._template)
+                                           self._template,
+                                           vtk_backend_grid=self._vtkDataSet)

--- a/Packages/vcs/Lib/vcsvtk/meshfillpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/meshfillpipeline.py
@@ -197,12 +197,13 @@ class MeshfillPipeline(Pipeline2D):
 
             # create a new renderer for this mapper
             # (we need one for each mapper because of cmaera flips)
-            self._context().fitToViewport(
+            self._context().fitToViewportBounds(
                 act, [self._template.data.x1,
                       self._template.data.x2,
                       self._template.data.y1,
                       self._template.data.y2],
-                wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
 
@@ -210,10 +211,11 @@ class MeshfillPipeline(Pipeline2D):
             if self._vtkGeoTransform is None:
                 # If using geofilter on wireframed does not get wrapped not sure
                 # why so sticking to many mappers
-                self._context().fitToViewport(
+                self._context().fitToViewportBounds(
                     act, [self._template.data.x1, self._template.data.x2,
                           self._template.data.y1, self._template.data.y2],
-                    wc=[x1, x2, y1, y2], geo=self._vtkGeoTransform,
+                    wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                    geo=self._vtkGeoTransform,
                     priority=self._template.data.priority,
                     create_renderer=True)
                 actors.append([act, [x1, x2, y1, y2]])
@@ -273,4 +275,5 @@ class MeshfillPipeline(Pipeline2D):
             projection = vcs.elements["projection"][self._gm.projection]
             self._context().plotContinents(x1, x2, y1, y2, projection,
                                            self._dataWrapModulo,
-                                           self._template)
+                                           self._template,
+                                           vtk_backend_grid=self._vtkDataSet)

--- a/Packages/vcs/Lib/vcsvtk/vectorpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/vectorpipeline.py
@@ -159,20 +159,22 @@ class VectorPipeline(Pipeline):
 
         act = vcs2vtk.doWrap(act, wc, self._dataWrapModulo)
 
-        self._context().fitToViewport(act, [tmpl.data.x1, tmpl.data.x2,
+        self._context().fitToViewportBounds(act, [tmpl.data.x1, tmpl.data.x2,
                                             tmpl.data.y1, tmpl.data.y2],
-                                      wc=wc,
-                                      priority=tmpl.data.priority,
-                                      create_renderer=True)
+                                            wc=wc,
+                                            priority=tmpl.data.priority,
+                                            create_renderer=True)
 
         returned.update(self._context().renderTemplate(tmpl, data1,
-                                                       self._gm, taxis, zaxis))
+                                                       self._gm, taxis, zaxis,
+                                                       vtk_backend_grid=returned["vtk_backend_grid"]))
 
         if self._context().canvas._continents is None:
             continents = False
         if continents:
             self._context().plotContinents(x1, x2, y1, y2, projection,
-                                           self._dataWrapModulo, tmpl)
+                                           self._dataWrapModulo, tmpl,
+                                           vtk_backend_grid=returned["vtk_backend_grid"])
 
         returned["vtk_backend_actors"] = [[act, [x1, x2, y1, y2]]]
         returned["vtk_backend_glyphfilters"] = [glyphFilter]


### PR DESCRIPTION
fitToViewport used to recompute the dataset bounds using an 2D array of points.
This was slow and imprecise. Now we pass the dataset bounds as parameters.