### PR TITLE
Axis labels now move when scaled by ratios

### DIFF
--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -866,9 +866,7 @@ class Canvas(object):
         vcs.next_canvas_id += 1
         self.colormap = None
         self.backgroundcolor = 255, 255, 255
-        # default size for bg
-        self.bgX = 814
-        self.bgY = 606
+
         # displays plotted
         self.display_names = []
         ospath = os.environ["PATH"]
@@ -955,6 +953,14 @@ class Canvas(object):
             else:
                 raise ValueError("geometry should be list, tuple, or dict")
             geometry = {"width": width, "height": height}
+
+        if geometry is not None and bg:
+            self.bgX = geometry["width"]
+            self.bgY = geometry["height"]
+        else:
+            # default size for bg
+            self.bgX = 814
+            self.bgY = 606
 
         if backend == "vtk":
             self.backend = VTKVCSBackend(self, geometry=geometry, bg=bg)

--- a/Packages/vcs/Lib/template.py
+++ b/Packages/vcs/Lib/template.py
@@ -2049,7 +2049,7 @@ class P(object):
         self.data._x2 = t.data._x2
         self.data._y1 = t.data._y1
         self.data._y2 = t.data._y2
-    # print odx,ndx
+
         if odx != ndx:
             self.data._x1 = max(0, min(1, self.data.x1 + (odx - ndx) / 2.))
             self.data._x2 = max(0, min(1, self.data.x2 + (odx - ndx) / 2.))
@@ -2058,6 +2058,13 @@ class P(object):
             self.data._y2 = max(0, min(1, self.data.y2 + (ody - ndy) / 2.))
 
         if box_and_ticks:
+            # Used to calculate label positions
+            x_scale = ndx / float(odx)
+            y_scale = ndy / float(ody)
+
+            x_label_name_diff = self.xlabel1.y - self.xname.y
+            y_label_name_diff = self.ylabel1.x - self.yname.x
+
             # Box1 resize
             self.box1._x1 = self.data._x1
             self.box1._x2 = self.data._x2
@@ -2103,6 +2110,10 @@ class P(object):
             # Ylabels
             self.ylabel1._x = max(0, min(1, self.ytic1._x1 + dX1))
             self.ylabel2._x = max(0, min(1, self.ytic2._x1 + dX2))
+
+            # Axis Names
+            self.xname.y = max(0, min(1, self.xlabel1._y - x_scale * x_label_name_diff))
+            self.yname.x = max(0, min(1, self.ylabel1._x - y_scale * y_label_name_diff))
             self.data._ratio = -Rwished
         else:
             self.data._ratio = Rwished

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -902,5 +902,12 @@ cdat_add_test(vcs_test_init_open_sizing
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_init_open_sizing.py
 )
 
+cdat_add_test(vcs_test_autot_axis_titles
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_autot_axis_titles.py
+  ${BASELINE_DIR}/test_autot_axis_titles_yname.png
+  ${BASELINE_DIR}/test_autot_axis_titles_xname.png
+)
+
 add_subdirectory(vtk_ui)
 add_subdirectory(editors)

--- a/testing/vcs/test_autot_axis_titles.py
+++ b/testing/vcs/test_autot_axis_titles.py
@@ -1,0 +1,43 @@
+import vcs
+import cdms2
+import os
+import sys
+
+src_yname = sys.argv[1]
+src_xname = sys.argv[2]
+pth = os.path.join(os.path.dirname(__file__), "..")
+sys.path.append(pth)
+
+import checkimage
+
+f = cdms2.open(vcs.sample_data + "/clt.nc")
+s = f("clt")
+x = vcs.init()
+x.setantialiasing(0)
+x.drawlogooff()
+x.plot(s, bg=1, ratio="autot")
+yname = "test_autot_axis_titles_yname.png"
+x.png(yname)
+
+# Work around background resize VTK bug
+x.close()
+x = vcs.init(bg=True, geometry=(500, 1000))
+x.setantialiasing(0)
+x.drawlogooff()
+x.plot(s, ratio="autot")
+xname = "test_autot_axis_titles_xname.png"
+x.png(xname)
+
+print "yname:", yname
+print "src:", src_yname
+
+ret = checkimage.check_result_image(yname, src_yname, checkimage.defaultThreshold)
+if ret > 0:
+    print "yname image did not match."
+    sys.exit(ret)
+
+print "xname:", xname
+print "src:", src_xname
+
+ret = checkimage.check_result_image(xname, src_xname, checkimage.defaultThreshold)
+sys.exit(ret)


### PR DESCRIPTION
Added `xname` and `yname` to the series of template attributes modified by setting the ratio. They are moved to a scaled-down percentage of the original difference between themselves and the corresponding `(x|y)label1` attribute.

The script:

```python
import vcs, cdms2
f = cdms2.open(vcs.sample_data + "/clt.nc")
s = f('clt')
x = vcs.init()
x.plot(s, ratio="autot")
```

Here's the original:

![bad](https://cloud.githubusercontent.com/assets/718512/12102894/13821824-b2f3-11e5-9703-89628a6de1c2.png)

If you shrank the width of the window, a similar thing would happen with the xname:

![tall_bad](https://cloud.githubusercontent.com/assets/718512/12102952/822c8a48-b2f3-11e5-8248-dc23d027e981.png)

After this PR:

![nice](https://cloud.githubusercontent.com/assets/718512/12102899/1b009c2e-b2f3-11e5-9faa-487b658c6b71.png)

and (still a bad plot, but the label is in the right place):

![tall_good](https://cloud.githubusercontent.com/assets/718512/12102978/acaa44ae-b2f3-11e5-83a0-fe84a862449d.png)
