### PR TITLE
Fixes issue with incorrect URIs for opendap urls

### DIFF
--- a/Packages/cdms2/Lib/dataset.py
+++ b/Packages/cdms2/Lib/dataset.py
@@ -966,7 +966,10 @@ class CdmsFile(CdmsObj, cuDataset):
                                 'mode']
         self.___cdms_internals__ = value
         self.id = path
-        self.uri="file://"+path
+        if "://" in path:
+            self.uri = path
+        else:
+            self.uri = "file://" + path
         self._mode_ = mode
         try:
             if mode[0].lower()=="w":


### PR DESCRIPTION
Fixes an issue where the URI for a CdmsFile was reported incorrectly if the file was obtained via a URL. Side effect of the naive original implementation 7ea5986594eb0d0650ef0196331ce3441c375fe7 (I'm blaming @doutriaux1, since I seem to have credited him with it in the first place :wink:)