### PR TITLE
Got rid of screen size logic from test

### DIFF
--- a/testing/vcs/test_vcs_init_open_sizing.py
+++ b/testing/vcs/test_vcs_init_open_sizing.py
@@ -46,12 +46,6 @@ def test_canvas_size(c, size, via):
     info = c.canvasinfo()
     w, h = size
 
-    # Make sure size fits on screen bounds
-    screen_w, screen_h = c.backend.renWin.GetScreenSize()
-    if w > screen_w:
-        w = screen_w
-    if h > screen_h:
-        h = screen_h
     assert info["width"] == w, "Width via %s incorrect; expected %d, got %d" % (via, w, info["width"])
     assert info["height"] == h, "Height via %s incorrect; expected %d, got %d" % (via, h, info["height"])
 


### PR DESCRIPTION
Not entirely certain why I put it there in the first place; test should run perfectly fine with a window that's bigger than the monitor.