### PR TITLE
Fixed bug that was breaking continents when set at canvas level

### DIFF
--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -977,6 +977,7 @@ class Canvas(object):
 
         self.configurator = None
         self.setcontinentsline("default")
+        self.setcontinentstype(1)
 
 # Initial.attributes is being called in main.c, so it is not needed here!
 # Actually it is for taylordiagram graphic methods....

--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -5354,8 +5354,7 @@ Options:::
                 return VCS_validation_functions.checkContinents(self, 1)
             else:
                 return path
-        except Exception as e:
-            print "Returning continents 1"
+        except:
             return VCS_validation_functions.checkContinents(self, 1)
 
     ##########################################################################

--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -801,7 +801,7 @@ class Canvas(object):
         if contout is None:
             if (xdim >= 0 and ydim >= 0 and tv.getAxis(xdim).isLongitude()
                     and tv.getAxis(ydim).isLatitude()) or (self.isplottinggridded):
-                contout = 1
+                contout = self.getcontinentstype()
             else:
                 contout = 0
 
@@ -5353,7 +5353,8 @@ Options:::
                 return VCS_validation_functions.checkContinents(self, 1)
             else:
                 return path
-        except:
+        except Exception as e:
+            print "Returning continents 1"
             return VCS_validation_functions.checkContinents(self, 1)
 
     ##########################################################################

--- a/testing/vcs/test_continents.py
+++ b/testing/vcs/test_continents.py
@@ -35,6 +35,7 @@ multitemplate = EzTemplate.Multi(template=dataonly, rows=4, columns=3)
 
 line_styles = ['long-dash', 'dot', 'dash', 'dash-dot', 'solid']
 
+
 for i in range(12):
     cont_index = i % 6 + 1
     cont_line = vcs.createline()
@@ -42,7 +43,12 @@ for i in range(12):
     cont_line.type = line_styles[i % 5]
     cont_line.color = i + 200
     template = multitemplate.get(i)
-    canvas.plot(clt, template, boxfill, continents=cont_index, continents_line=cont_line, bg=1)
+    if cont_index != 3:
+        canvas.plot(clt, template, boxfill, continents=cont_index, continents_line=cont_line, bg=1)
+    else:
+        canvas.setcontinentsline(cont_line)
+        canvas.setcontinentstype(3)
+        canvas.plot(clt, template, boxfill, bg=1)
 
 # Load the image testing module:
 testingDir = os.path.join(os.path.dirname(__file__), "..")


### PR DESCRIPTION
Found a bug that wasn't properly covered by my test_continents script; if you set the continents at the canvas level, rather than by using the continents argument of the plot function, the continents would be ignored.