### PR TITLE
Fix wrong ratio on init

### DIFF
--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -359,8 +359,8 @@ class Canvas(object):
         'ParameterChanged',
         'colormap',
         'backgroundcolor',
-        'bgX',
-        'bgY',
+        '_bgX',
+        '_bgY',
         'display_names',
         '_dotdir',
         '_dotdirenv',
@@ -954,13 +954,7 @@ class Canvas(object):
                 raise ValueError("geometry should be list, tuple, or dict")
             geometry = {"width": width, "height": height}
 
-        if geometry is not None and bg:
-            self.bgX = geometry["width"]
-            self.bgY = geometry["height"]
-        else:
-            # default size for bg
-            self.bgX = 814
-            self.bgY = 606
+
 
         if backend == "vtk":
             self.backend = VTKVCSBackend(self, geometry=geometry, bg=bg)
@@ -972,6 +966,14 @@ class Canvas(object):
                 "backend, no warranty about anything working from this point on" %
                 backend)
             self.backend = backend
+
+        if geometry is not None and bg:
+            self.bgX = geometry["width"]
+            self.bgY = geometry["height"]
+        else:
+            # default size for bg
+            self._bgX = 814
+            self._bgY = 606
 
         self._animate = self.backend.Animate(self)
 
@@ -2473,13 +2475,16 @@ Options:::
         return new
 
     def __plot(self, arglist, keyargs):
-            # This routine has five arguments in arglist from _determine_arg_list
-            # It adds one for bg and passes those on to Canvas.plot as its sixth
-            # arguments.
+        # Make sure the backend is in bg mode
+        if "bg" in keyargs:
+            self.backend.bg = keyargs["bg"]
+        # This routine has five arguments in arglist from _determine_arg_list
+        # It adds one for bg and passes those on to Canvas.plot as its sixth
+        # arguments.
 
-            # First of all let's remember which elets we have before comin in here
-            # so that anything added (temp objects) can be removed at clear
-            # time
+        # First of all let's remember which elets we have before comin in here
+        # so that anything added (temp objects) can be removed at clear
+        # time
         original_elts = {}
         new_elts = {}
         for k in vcs.elements.keys():
@@ -4696,6 +4701,24 @@ Options:::
     def setantialiasing(self, antialiasing):
         """ Turn ON/OFF antialiasing"""
         self.backend.setantialiasing(antialiasing)
+
+    def _setbgx(self, value):
+        self.backend.bg = True
+        self._bgX = value
+
+    def _getbgx(self):
+        return self._bgX
+
+    bgX = property(_getbgx, _setbgx)
+
+    def _setbgy(self, value):
+        self.backend.bg = True
+        self._bgY = value
+
+    def _getbgy(self):
+        return self._bgY
+
+    bgY = property(_getbgy, _setbgy)
 
     ##########################################################################
     #                                                                        #

--- a/Packages/vcs/Lib/Canvas.py
+++ b/Packages/vcs/Lib/Canvas.py
@@ -2473,7 +2473,6 @@ Options:::
         return new
 
     def __plot(self, arglist, keyargs):
-
             # This routine has five arguments in arglist from _determine_arg_list
             # It adds one for bg and passes those on to Canvas.plot as its sixth
             # arguments.

--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -378,23 +378,18 @@ class VTKVCSBackend(object):
 
     def canvasinfo(self):
         if self.renWin is None:
-            mapstate = False
-            height = self.canvas.bgY
-            width = self.canvas.bgX
-            depth = None
-            x = 0
-            y = 0
-        else:
-            try:  # mac but not linux
-                mapstate = self.renWin.GetWindowCreated()
-            except:
-                mapstate = True
-            width, height = self.renWin.GetSize()
-            depth = self.renWin.GetDepthBufferSize()
-            try:  # mac not linux
-                x, y = self.renWin.GetPosition()
-            except:
-                x, y = 0, 0
+            self.createRenWin(open=False)
+
+        try:  # mac but not linux
+            mapstate = self.renWin.GetWindowCreated()
+        except:
+            mapstate = True
+        width, height = self.renWin.GetSize()
+        depth = self.renWin.GetDepthBufferSize()
+        try:  # mac not linux
+            x, y = self.renWin.GetPosition()
+        except:
+            x, y = 0, 0
         info = {
             "mapstate": mapstate,
             "height": height,

--- a/Packages/vcsaddons/Lib/Multi.py
+++ b/Packages/vcsaddons/Lib/Multi.py
@@ -209,18 +209,11 @@ class Multi(object):
         self.spacing = Spacing(horizontal_spacing,vertical_spacing)
         self.legend  = Legend(direction=legend_direction,fat=legend_fat,thickness=legend_thickness,stretch=legend_stretch)
 
-        found=False
-	if x is not None:
-		self.x=x
-	else:
-          for obj in globals():
-            if isinstance(obj,vcs.Canvas.Canvas):
-                self.x=obj
-                found=True
-                break
-          if found is False:
-            self.x=vcs.init()
-            
+        if x is not None:
+            self.x = x
+        else:
+            self.x = vcs.init(bg=True)
+
         self.template_names = []
         self.template=template
 
@@ -343,7 +336,7 @@ class Multi(object):
         t.legend.y2=min(1,max(0,y2-(y2-y1)*(1.-dy)/2.))
         return t
 
-    def preview(self,out='EZTemplate_Multi',bg=1):
+    def preview(self,out='EZTemplate_Multi',bg=True):
         """ Draws the layout for your setup, return the vcs canvas on which this was drawn
         Usage
         canvas = Multi.preview(out='EZTemplate_Multi',bg=1)


### PR DESCRIPTION
PR for #1795 ; still fails on Diagnostics tests.

The diagnostics tests fail because:

1. diagnostics calls `canvas.portrait()`
2. `canvas.portrait()` calls `backend.portrait()` with height/width from updated `canvasinfo` function
3. `backend.portrait()` calls `backend.resize_or_rotate_window` with height/width
4. `backend.resize_or_rotate_window` sets `bgX` and `bgY` with the updated height/width
5. :beetle: 

I'm probably going to try updating `canvas.portrait` to just update the `size` attribute on the canvas if height/width was not specified; that will make all of the output functions correctly flip the dimensions when needed, and prevent the vicious chain of bugs.
