### PR TITLE
BUG #1809: Error wrapping a curved grid with masking.

### DIFF
--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -311,6 +311,12 @@ cdat_add_test(vcs_test_boxfill_decreasing_latitude
   "${BASELINE_DIR}/test_vcs_boxfill_decreasing_latitude.png"
   "${UVCDAT_GIT_TESTDATA_DIR}/data/decreasing_latitude.nc"
   )
+cdat_add_test(vcs_test_meshfill_no_wrapping
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/vcs_test_meshfill_no_wrapping.py
+  "${BASELINE_DIR}/vcs_test_meshfill_no_wrapping.png"
+  "${UVCDAT_GIT_TESTDATA_DIR}/data/heat.nc"
+  )
 cdat_add_test(vcs_test_boxfill_10x10_numpy
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_boxfill_10x10_numpy.py

--- a/testing/vcs/vcs_test_meshfill_no_wrapping.py
+++ b/testing/vcs/vcs_test_meshfill_no_wrapping.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import cdms2 
+import os 
+import sys
+import vcs
+
+pth = os.path.join(os.path.dirname(__file__), "..")
+sys.path.append(pth)
+import checkimage
+
+
+f=cdms2.open(sys.argv[2])
+h=f("heat")
+x=vcs.init()
+x.setantialiasing(0)
+x.drawlogooff()
+x.setbgoutputdimensions(1200, 900, units="pixels")
+
+x.plot(h, bg=1)
+fnm = "vcs_test_meshfill_no_wrapping.png"
+x.png(fnm)
+ret = checkimage.check_result_image(fnm, sys.argv[1], checkimage.defaultThreshold)
+sys.exit(ret)


### PR DESCRIPTION
Failed to consider the case: masking + an unstructured grid that was not
wrapped, so it did not have pedigree ids. This can happen if longitude
range is less than 360. Added a test for this case.