### PR TITLE
Add nc_del_attr to Cdunif to allow attribute removal in netCDF files

### DIFF
--- a/Packages/cdms2/Lib/dataset.py
+++ b/Packages/cdms2/Lib/dataset.py
@@ -1165,7 +1165,8 @@ class CdmsFile(CdmsObj, cuDataset):
                   (self.__class__.__name__, name))
         if not name in self.__cdms_internals__:
             delattr(self._file_, name)
-            del(self.attributes[name])
+            if( name in self.attributes.keys() ):
+                del(self.attributes[name])
 
     def sync(self):
         """

--- a/testing/cdms2/CDMS_Test_del_attributes.py
+++ b/testing/cdms2/CDMS_Test_del_attributes.py
@@ -1,17 +1,18 @@
 import cdms2, MV2
-f = cdms2.open("test.nc","w")
+test_nm = 'CDMS_Test_del_attributes.nc'
+f = cdms2.open(test_nm,"w")
 s = MV2.ones((20,20))
 s.id="test"
 s.test_attribute = "some variable attribute"
 f.test_attribute = "some file attribute"
 f.write(s)
 f.close()
-f = cdms2.open("test.nc","r+")
+f = cdms2.open(test_nm,"r+")
 delattr(f,'test_attribute')
 s=f["test"]
 del(s.test_attribute)
 f.close()
-f = cdms2.open("test.nc")
+f = cdms2.open(test_nm)
 assert(hasattr(f,'test_attribute') is False)
 s=f["test"]
 assert(hasattr(s,'test_attribute') is False)

--- a/testing/cdms2/CDMS_Test_del_attributes.py
+++ b/testing/cdms2/CDMS_Test_del_attributes.py
@@ -1,0 +1,17 @@
+import cdms2, MV2
+f = cdms2.open("test.nc","w")
+s = MV2.ones((20,20))
+s.id="test"
+s.test_attribute = "some variable attribute"
+f.test_attribute = "some file attribute"
+f.write(s)
+f.close()
+f = cdms2.open("test.nc","r+")
+delattr(f,'test_attribute')
+s=f["test"]
+del(s.test_attribute)
+f.close()
+f = cdms2.open("test.nc")
+assert(hasattr(f,'test_attribute') is False)
+s=f["test"]
+assert(hasattr(s,'test_attribute') is False)

--- a/testing/cdms2/CMakeLists.txt
+++ b/testing/cdms2/CMakeLists.txt
@@ -145,6 +145,10 @@ cdat_add_test("CDMS_Test_write_extended_dimension"
     "${PYTHON_EXECUTABLE}"
     ${cdat_SOURCE_DIR}/testing/cdms2/test_simple_write.py)
 
+cdat_add_test("CDMS_Test_del_attributes"
+    "${PYTHON_EXECUTABLE}"
+    ${cdat_SOURCE_DIR}/testing/cdms2/CDMS_Test_del_attributes.py)
+
 
 # Tests which should fail
 # set_tests_properties(testSo2TasACCESSFails PROPERTIES PASS_REGULAR_EXPRESSION "FAILED")


### PR DESCRIPTION
Allow to delete Global Attributes or Variable attributes when calling del(f.attribute) or delattr(f, attribute).   Cdunifmodule "set_attribute" function is called with a null pointer "0x00" which is different than Py_None.   Without this change deleting an attribute with a "del" or "delattr" call was crashing the program with a segmentation fault. 