### PR TITLE
BUG #1849: Re-enable datawc for linear projection.

### DIFF
--- a/Packages/vcs/Lib/VTKPlots.py
+++ b/Packages/vcs/Lib/VTKPlots.py
@@ -697,11 +697,6 @@ class VTKVCSBackend(object):
         contActor = vtk.vtkActor()
         contActor.SetMapper(contMapper)
         contActor = vcs2vtk.doWrap(contActor, wc, fastClip=False)
-        if vcs2vtk._DEBUG_VTK:
-            writer = vtk.vtkXMLPolyDataWriter()
-            writer.SetFileName("cont.vtp")
-            writer.SetInputData(contActor.GetMapper().GetInput())
-            writer.Write()
 
         if projection.type != "linear":
             contData = contActor.GetMapper().GetInput()
@@ -710,12 +705,6 @@ class VTKVCSBackend(object):
             # that parameters such that central meridian are set correctly.
             geo, gcpts = vcs2vtk.project(cpts, projection, wc)
             contData.SetPoints(gcpts)
-
-            if vcs2vtk._DEBUG_VTK:
-                writerg = vtk.vtkXMLPolyDataWriter()
-                writerg.SetFileName("contg.vtp")
-                writerg.SetInputData(contData)
-                writerg.Write()
 
             contMapper = vtk.vtkPolyDataMapper()
             contMapper.SetInputData(contData)

--- a/Packages/vcs/Lib/taylor.py
+++ b/Packages/vcs/Lib/taylor.py
@@ -1884,9 +1884,6 @@ class Gtd(object):
         d = self.drawSkill(canvas, values=self.skillValues, function=skill)
         if (d):
             self.displays.append(d)
-        if (len(self.displays) > 0):
-            datasetBounds = self.displays[-1].backend['dataset_bounds']
-            self.worldcoordinate = datasetBounds
         self.drawFrame(canvas, data, wc)
         self.draw(canvas, data)
         # Ok now draws the little comment/source, etc

--- a/Packages/vcs/Lib/vcs2vtk.py
+++ b/Packages/vcs/Lib/vcs2vtk.py
@@ -15,8 +15,6 @@ import numbers
 f = open(os.path.join(vcs.prefix, "share", "vcs", "wmo_symbols.json"))
 wmo = json.load(f)
 
-_DEBUG_VTK = False
-
 projNames = [
     "linear",
     "utm",
@@ -267,19 +265,7 @@ def genGridOnPoints(data1, gm, deep=True, grid=None, geo=None,
         else:
             vg = vtk.vtkUnstructuredGrid()
         vg.SetPoints(oldpts)
-        if (_DEBUG_VTK):
-            writer = vtk.vtkXMLDataSetWriter()
-            writer.SetFileName("lonlat-p.vts")
-            writer.SetInputData(vg)
-            writer.Write()
-
         vg.SetPoints(pts)
-        if _DEBUG_VTK:
-            writerg = vtk.vtkXMLDataSetWriter()
-            writerg.SetFileName("geo-p.vts")
-            writerg.SetInputData(vg)
-            writerg.Write()
-
     else:
         vg = grid
     scalar = numpy_to_vtk_wrapper(data1.filled(0.).flat,
@@ -511,12 +497,6 @@ def genGrid(data1, data2, gm, deep=True, grid=None, geo=None):
     projection = vcs.elements["projection"][gm.projection]
     if grid is None:
         vg.SetPoints(pts)
-
-        writer = vtk.vtkXMLDataSetWriter()
-        ext = "vts" if (vg.GetDataObjectType() == vtk.VTK_STRUCTURED_GRID) else "vtu"
-        writer.SetFileName("lonlat." + ext)
-        writer.SetInputData(vg)
-        writer.Write()
         # Even if we don't use the zooming feature (gm.datawc) for geographic
         # projections
         # we use plotting coordinates for doing the projection
@@ -525,19 +505,8 @@ def genGrid(data1, data2, gm, deep=True, grid=None, geo=None):
             [gm.datawc_x1, gm.datawc_x2, gm.datawc_y1, gm.datawc_y2], [xm, xM, ym, yM], wrap))
         # Sets the vertics into the grid
         vg.SetPoints(geopts)
-
-        writerg = vtk.vtkXMLDataSetWriter()
-        writerg.SetFileName("geo." + ext)
-        writerg.SetInputData(vg)
-        writerg.Write()
-
     else:
         vg = grid
-        writer = vtk.vtkXMLDataSetWriter()
-        writer.SetFileName("lonlat.vts")
-        writer.SetInputData(vg)
-        writer.Write()
-
     out = {"vtk_backend_grid": vg,
            "xm": xm,
            "xM": xM,
@@ -1679,11 +1648,7 @@ def stippleLine(prop, line_type):
         raise Exception("Unknown line type: '%s'" % line_type)
 
 
-counti = 0
-
-
 def prepLine(renWin, line, cmap=None):
-    global counti
     number_lines = prepPrimitive(line)
     if number_lines == 0:
         return []
@@ -1758,25 +1723,12 @@ def prepLine(renWin, line, cmap=None):
             l.GetPointIds().SetId(1, j + point_offset + 1)
             lines.InsertNextCell(l)
 
-    countj = 0
     for t, w in line_data:
         pts, _, linesPoly, colors = line_data[(t, w)]
 
         linesPoly.GetCellData().SetScalars(colors)
-        if _DEBUG_VTK:
-            writer = vtk.vtkXMLPolyDataWriter()
-            writer.SetFileName("poly" + str(counti) + "-" + str(countj) + ".vtp")
-            writer.SetInputData(linesPoly)
-            writer.Write()
-
         geo, pts = project(pts, line.projection, line.worldcoordinate)
         linesPoly.SetPoints(pts)
-
-        if _DEBUG_VTK:
-            writerg = vtk.vtkXMLPolyDataWriter()
-            writerg.SetFileName("polyg" + str(counti) + "-" + str(countj) + ".vtp")
-            writerg.SetInputData(linesPoly)
-            writerg.Write()
 
         a = vtk.vtkActor()
         m = vtk.vtkPolyDataMapper()
@@ -1788,9 +1740,7 @@ def prepLine(renWin, line, cmap=None):
 
         stippleLine(p, t)
         actors.append((a, geo))
-        countj = countj + 1
 
-    counti = counti + 1
     return actors
 
 

--- a/Packages/vcs/Lib/vcsvtk/isofillpipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/isofillpipeline.py
@@ -58,7 +58,8 @@ class IsofillPipeline(Pipeline2D):
         mappers = []
         _colorMap = self.getColorMap()
 
-        x1, x2, y1, y2 = self.getBoundsForPlotting()
+        plotting_dataset_bounds = self.getPlottingBounds()
+        x1, x2, y1, y2 = plotting_dataset_bounds
 
         for i, l in enumerate(tmpLevels):
             # Ok here we are trying to group together levels can be, a join
@@ -142,15 +143,15 @@ class IsofillPipeline(Pipeline2D):
             if self._vtkGeoTransform is None:
                 # If using geofilter on wireframed does not get wrppaed not
                 # sure why so sticking to many mappers
-                act = vcs2vtk.doWrap(act, [x1, x2, y1, y2],
+                act = vcs2vtk.doWrap(act, plotting_dataset_bounds,
                                      self._dataWrapModulo)
 
             patact = None
             # TODO see comment in boxfill.
             if mapper is self._maskedDataMapper:
-                actors.append([act, self._maskedDataMapper, [x1, x2, y1, y2]])
+                actors.append([act, self._maskedDataMapper, plotting_dataset_bounds])
             else:
-                actors.append([act, [x1, x2, y1, y2]])
+                actors.append([act, plotting_dataset_bounds])
 
                 # Since pattern creation requires a single color, assuming the first
                 c = self.getColorIndexOrRGBA(_colorMap, tmpColors[ct][0])
@@ -175,7 +176,7 @@ class IsofillPipeline(Pipeline2D):
             # (we need one for each mapper because of cmaera flips)
             self._context().fitToViewportBounds(
                 act, vp,
-                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
@@ -183,11 +184,11 @@ class IsofillPipeline(Pipeline2D):
         for act in patternActors:
             self._context().fitToViewportBounds(
                 act, vp,
-                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
-            actors.append([act, [x1, x2, y1, y2]])
+            actors.append([act, plotting_dataset_bounds])
 
         self._resultDict["vtk_backend_actors"] = actors
 
@@ -203,7 +204,7 @@ class IsofillPipeline(Pipeline2D):
             self._gm, t, z,
             vtk_backend_grid=self._vtkDataSet,
             dataset_bounds=self._vtkDataSetBounds,
-            plotting_dataset_bounds=[x1, x2, y1, y2]))
+            plotting_dataset_bounds=plotting_dataset_bounds))
 
         legend = getattr(self._gm, "legend", None)
 
@@ -240,7 +241,7 @@ class IsofillPipeline(Pipeline2D):
             self._useContinents = False
         if self._useContinents:
             projection = vcs.elements["projection"][self._gm.projection]
-            self._context().plotContinents(x1, x2, y1, y2, projection,
+            self._context().plotContinents(plotting_dataset_bounds, projection,
                                            self._dataWrapModulo,
                                            vp, self._template.data.priority,
                                            vtk_backend_grid=self._vtkDataSet,

--- a/Packages/vcs/Lib/vcsvtk/isolinepipeline.py
+++ b/Packages/vcs/Lib/vcsvtk/isolinepipeline.py
@@ -81,7 +81,8 @@ class IsolinePipeline(Pipeline2D):
             # fill up the line style values
             linestyle += ['solid'] * (len(self._contourLevels) - len(linestyle))
 
-        x1, x2, y1, y2 = self.getBoundsForPlotting()
+        plotting_dataset_bounds = self.getPlottingBounds()
+        x1, x2, y1, y2 = plotting_dataset_bounds
 
         for i, l in enumerate(self._contourLevels):
             if i == 0:
@@ -282,15 +283,15 @@ class IsolinePipeline(Pipeline2D):
             if self._vtkGeoTransform is None:
                 # If using geofilter on wireframed does not get wrppaed not
                 # sure why so sticking to many mappers
-                act = vcs2vtk.doWrap(act, [x1, x2, y1, y2],
+                act = vcs2vtk.doWrap(act, plotting_dataset_bounds,
                                      self._dataWrapModulo)
-            actors.append([act, [x1, x2, y1, y2]])
+            actors.append([act, plotting_dataset_bounds])
 
             # create a new renderer for this mapper
             # (we need one for each mapper because of cmaera flips)
             self._context().fitToViewportBounds(
                 act, vp,
-                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
@@ -315,14 +316,14 @@ class IsolinePipeline(Pipeline2D):
             if self._vtkGeoTransform is None:
                 # If using geofilter on wireframed does not get wrppaed not
                 # sure why so sticking to many mappers
-                act = vcs2vtk.doWrap(act, [x1, x2, y1, y2],
+                act = vcs2vtk.doWrap(act, plotting_dataset_bounds,
                                      self._dataWrapModulo)
-            actors.append([act, self._maskedDataMapper, [x1, x2, y1, y2]])
+            actors.append([act, self._maskedDataMapper, plotting_dataset_bounds])
             # create a new renderer for this mapper
             # (we need one for each mapper because of cmaera flips)
             self._context().fitToViewportBounds(
                 act, vp,
-                wc=[x1, x2, y1, y2], geoBounds=self._vtkDataSet.GetBounds(),
+                wc=plotting_dataset_bounds, geoBounds=self._vtkDataSet.GetBounds(),
                 geo=self._vtkGeoTransform,
                 priority=self._template.data.priority,
                 create_renderer=True)
@@ -341,13 +342,13 @@ class IsolinePipeline(Pipeline2D):
             self._gm, t, z,
             vtk_backend_grid=self._vtkDataSet,
             dataset_bounds=self._vtkDataSetBounds,
-            plotting_dataset_bounds=[x1, x2, y1, y2]))
+            plotting_dataset_bounds=plotting_dataset_bounds))
 
         if self._context().canvas._continents is None:
             self._useContinents = False
         if self._useContinents:
             projection = vcs.elements["projection"][self._gm.projection]
-            self._context().plotContinents(x1, x2, y1, y2, projection,
+            self._context().plotContinents(plotting_dataset_bounds, projection,
                                            self._dataWrapModulo,
                                            vp, self._template.data.priority,
                                            vtk_backend_grid=self._vtkDataSet,

--- a/Packages/vcs/Lib/vcsvtk/pipeline2d.py
+++ b/Packages/vcs/Lib/vcsvtk/pipeline2d.py
@@ -337,12 +337,19 @@ class Pipeline2D(IPipeline2D):
         self._resultDict["vtk_backend_missing_mapper"] = (
             self._maskedDataMapper, color, self._useCellScalars)
 
-    def getBoundsForPlotting(self):
-        """This is the same as lon/lat dataset bounds but it
-           matches the order of the bounds comming from gm
+    def getPlottingBounds(self):
+        """gm.datawc if it is set or dataset_bounds if there is not geographic projection
+           wrapped bounds otherwise
         """
-        return vcs2vtk.getBoundsForPlotting(
-            vcs.utils.getworldcoordinates(self._gm,
-                                          self._data1.getAxis(-1),
-                                          self._data1.getAxis(-2)),
-            self._vtkDataSetBounds, self._dataWrapModulo)
+        if (self._vtkGeoTransform):
+            return vcs2vtk.getWrappedBounds(
+                vcs.utils.getworldcoordinates(self._gm,
+                                              self._data1.getAxis(-1),
+                                              self._data1.getAxis(-2)),
+                self._vtkDataSetBounds, self._dataWrapModulo)
+        else:
+            return vcs2vtk.getPlottingBounds(
+                vcs.utils.getworldcoordinates(self._gm,
+                                              self._data1.getAxis(-1),
+                                              self._data1.getAxis(-2)),
+                self._vtkDataSetBounds, self._vtkGeoTransform)

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -322,6 +322,23 @@ cdat_add_test(vcs_test_boxfill_robinson_wrap
   ${cdat_SOURCE_DIR}/testing/vcs/vcs_test_boxfill_robinson_wrap.py
   "${BASELINE_DIR}/vcs_test_boxfill_robinson_wrap.png"
   )
+cdat_add_test(vcs_test_meshfill_zoom
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/vcs_test_meshfill_zoom.py
+  "${BASELINE_DIR}/vcs_test_meshfill_zoom.png"
+  )
+cdat_add_test(vcs_test_meshfill_zoom_flip
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/vcs_test_meshfill_zoom.py
+  "${BASELINE_DIR}/vcs_test_meshfill_zoom_flip.png"
+  flip
+  )
+cdat_add_test(vcs_test_meshfill_zoom_flip
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/vcs_test_meshfill_zoom.py
+  "${BASELINE_DIR}/vcs_test_meshfill_zoom_flip.png"
+  flip
+  )
 cdat_add_test(vcs_test_boxfill_10x10_numpy
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_boxfill_10x10_numpy.py

--- a/testing/vcs/vcs_test_boxfill_robinson_wrap.py
+++ b/testing/vcs/vcs_test_boxfill_robinson_wrap.py
@@ -3,7 +3,7 @@ import cdms2, cdutil, genutil
 import vcs,os
 import sys
 
-# This tests if extening the longitude to more than 360 decrees is handled correctly by
+# This tests if extending the longitude to more than 360 decrees is handled correctly by
 # proj4. See https://github.com/UV-CDAT/uvcdat/issues/1728 for more information.
 pth = os.path.join(os.path.dirname(__file__), "..")
 sys.path.append(pth)

--- a/testing/vcs/vcs_test_meshfill_zoom.py
+++ b/testing/vcs/vcs_test_meshfill_zoom.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import cdms2
+import os
+import sys
+import vcs
+
+# We test if gm.datawc zooms in correctly into the plot. This works only for
+# data using a linear projection. It does not work for geographic projections.
+pth = os.path.join(os.path.dirname(__file__), "..")
+sys.path.append(pth)
+import checkimage
+
+flip = False
+if (len(sys.argv) == 3):
+    flip = True
+
+fileName = os.path.basename(__file__)
+fileName = os.path.splitext(fileName)[0]
+if (flip):
+    fileName = fileName + '_flip'
+fileName = fileName + '.png'
+f=cdms2.open(os.path.join(vcs.sample_data, "sampleCurveGrid4.nc"))
+s=f("sample")
+x=vcs.init()
+x.setantialiasing(0)
+x.drawlogooff()
+m=x.createmeshfill()
+# m.mesh = True
+m.datawc_x1 = -20
+m.datawc_x2 = 20
+if (flip):
+    m.datawc_x1, m.datawc_x2 = m.datawc_x2, m.datawc_x1
+m.datawc_y1 = -20
+m.datawc_y2 = 20
+x.plot(s,m, bg=1)
+x.png(fileName)
+ret = checkimage.check_result_image(fileName, sys.argv[1], checkimage.defaultThreshold)
+sys.exit(ret)
+


### PR DESCRIPTION
For datasets using a geographic projection, datawc
is only used to specify wrapping (translation of the origin,
for instance from 0:360 to -180:180) and flipping.