### PR TITLE
Allow canvas.plot to handle vcs addons

### DIFF
--- a/Packages/vcs/vcs/utils.py
+++ b/Packages/vcs/vcs/utils.py
@@ -1625,7 +1625,7 @@ def getgraphicsmethod(type, name):
         type = "boxfill"
     if isinstance(type, vcsaddons.core.VCSaddon):
         func = type.getgm
-        copy_mthd = func(source=name)
+        copy_mthd = func(name)
     else:
         try:
             copy_mthd = vcs.elements[type][name]


### PR DESCRIPTION
Fixes a bug where passing a vcsaddon graphics method to canvas.plot would raise an exception.