### PR TITLE
BUG: Fix memory override for vtkContourFiler in isofillpipeline.

### DIFF
--- a/Packages/vcs/vcs/vcs2vtk.py
+++ b/Packages/vcs/vcs/vcs2vtk.py
@@ -1581,16 +1581,16 @@ def __build_ld__():
 
 def stippleLine(prop, line_type):
     if line_type == 'long-dash':
-        prop.SetLineStipplePattern(int('1111111100000000', 2))
+        prop.SetLineStipplePattern(int('0000111111111111', 2))
         prop.SetLineStippleRepeatFactor(1)
     elif line_type == 'dot':
-        prop.SetLineStipplePattern(int('1010101010101010', 2))
+        prop.SetLineStipplePattern(int('0101010101010101', 2))
         prop.SetLineStippleRepeatFactor(1)
     elif line_type == 'dash':
-        prop.SetLineStipplePattern(int('1111000011110000', 2))
+        prop.SetLineStipplePattern(int('0001111100011111', 2))
         prop.SetLineStippleRepeatFactor(1)
     elif line_type == 'dash-dot':
-        prop.SetLineStipplePattern(int('0011110000110011', 2))
+        prop.SetLineStipplePattern(int('0101111101011111', 2))
         prop.SetLineStippleRepeatFactor(1)
     elif line_type == 'solid':
         prop.SetLineStipplePattern(int('1111111111111111', 2))

--- a/Packages/vcs/vcs/vcsvtk/isolinepipeline.py
+++ b/Packages/vcs/vcs/vcsvtk/isolinepipeline.py
@@ -144,7 +144,6 @@ class IsolinePipeline(Pipeline2D):
 
             for n in range(numLevels):
                 cot.SetValue(n, l[n])
-            cot.SetValue(numLevels, l[-1])
             # TODO remove update
             cot.Update()
 

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -1007,6 +1007,13 @@ cdat_add_test(test_vcs_boxfill_lambert_crash
   "${BASELINE_DIR}/test_vcs_boxfill_lambert_crash.png"
   "${UVCDAT_GIT_TESTDATA_DIR}/data/NCEP_09_climo.nc"
 )
+
+cdat_add_test(test_vcs_line_patterns
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_line_patterns.py
+  "${BASELINE_DIR}/test_vcs_line_patterns.png"
+)
+
 cdat_add_test(test_vcs_init_open_sizing
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_init_open_sizing.py

--- a/testing/vcs/test_vcs_line_patterns.py
+++ b/testing/vcs/test_vcs_line_patterns.py
@@ -1,0 +1,22 @@
+import vcs
+import cdms2
+import sys
+import os
+import testing.regression as regression
+
+
+pth = os.path.join(os.path.dirname(__file__), "..")
+sys.path.append(pth)
+
+import checkimage
+
+x = regression.init(bg=1, geometry=(1620, 1080))
+
+f = cdms2.open(vcs.sample_data + "/clt.nc")
+s = f('clt')
+iso = x.createisoline()
+iso.level=[5, 50, 70, 95]
+iso.line = ['dot', 'dash', 'dash-dot', 'long-dash']
+x.plot(s,iso,continents=0)
+name = "test_vcs_line_patterns.png"
+regression.run(x, name)


### PR DESCRIPTION
This resulted in vtkStripper to generate double coverage of isocountours which resulted in
messed-up patterns.
Also adjusted plot patterns to easier to discriminate.