### PR TITLE
BUG: Extend the isoline attribute list with the last value from the e…

### DIFF
--- a/Packages/vcs/vcs/isoline.py
+++ b/Packages/vcs/vcs/isoline.py
@@ -310,6 +310,8 @@ class Gi(object):
         iso.linewidths=([1,2,3,4,5,6,7,8])	# Will set the isoline to a specific
                                                 #     width size
         iso.linewidths=None			# Turns off the line width size
+    If the number of line styles, colors or widths are less than the number of levels
+    we extend the attribute list using the last attribute value in the attribute list.
 
     There are three ways to specify the text or font number:
         iso.text=(1,2,3,4,5,6,7,8,9)     	# Font numbers are between 1 and 9

--- a/Packages/vcs/vcs/vcsvtk/isolinepipeline.py
+++ b/Packages/vcs/vcs/vcsvtk/isolinepipeline.py
@@ -14,6 +14,14 @@ class IsolinePipeline(Pipeline2D):
         super(IsolinePipeline, self).__init__(gm, context_)
         self._needsCellData = False
 
+    def extendAttribute(self, attributes, default):
+        if len(attributes) < len(self._contourLevels):
+            if (len(attributes) == 0):
+                attributeValue = default
+            else:
+                attributeValue = attributes[-1]
+            attributes += [attributeValue] * (len(self._contourLevels) - len(attributes))
+
     def _updateContourLevelsAndColors(self):
         """Overrides baseclass implementation."""
         # Contour values:
@@ -31,9 +39,8 @@ class IsolinePipeline(Pipeline2D):
             else:
                 if numpy.allclose(self._contourLevels[0], 1.e20):
                     self._contourLevels[0] = -1.e20
-
-        # Contour colors:
         self._contourColors = self._gm.linecolors
+        self.extendAttribute(self._contourColors, default='black')
 
     def _plotInternal(self):
         """Overrides baseclass implementation."""
@@ -43,15 +50,10 @@ class IsolinePipeline(Pipeline2D):
         tmpLineStyles = []
 
         linewidth = self._gm.linewidths
+        self.extendAttribute(linewidth, default=1.0)
+
         linestyle = self._gm.line
-
-        if len(linewidth) < len(self._contourLevels):
-            # fill up the line width values
-            linewidth += [1.0] * (len(self._contourLevels) - len(linewidth))
-
-        if len(linestyle) < len(self._contourLevels):
-            # fill up the line style values
-            linestyle += ['solid'] * (len(self._contourLevels) - len(linestyle))
+        self.extendAttribute(linestyle, default='solid')
 
         plotting_dataset_bounds = self.getPlottingBounds()
         x1, x2, y1, y2 = plotting_dataset_bounds
@@ -69,20 +71,14 @@ class IsolinePipeline(Pipeline2D):
                 if W == linewidth[i] and S == linestyle[i]:
                     # Ok same style and width, lets keep going
                     L.append(l)
-                    if i >= len(self._contourColors):
-                        C.append(self._contourColors[-1])
-                    else:
-                        C.append(self._contourColors[i])
+                    C.append(self._contourColors[i])
                 else:
                     tmpLevels.append(L)
                     tmpColors.append(C)
                     tmpLineWidths.append(W)
                     tmpLineStyles.append(S)
                     L = [l]
-                    if i >= len(self._contourColors):
-                        C = [self._contourColors[-1]]
-                    else:
-                        C = [self._contourColors[i]]
+                    C = [self._contourColors[i]]
                     W = linewidth[i]
                     S = linestyle[i]
 

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -692,6 +692,11 @@ cdat_add_test(test_vcs_settings_color_name_rgba
    ENDFOREACH(ptype)
   ENDFOREACH(gm)
 
+  cdat_add_test(test_vcs_isoline_extend_attributes
+    "${PYTHON_EXECUTABLE}"
+    ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_isoline_extend_attributes.py
+    ${BASELINE_DIR}/test_vcs_isoline_extend_attributes.png
+    )
   cdat_add_test(test_vcs_isoline_numpy
     "${PYTHON_EXECUTABLE}"
     ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_isoline_numpy.py

--- a/testing/vcs/test_vcs_isoline_extend_attributes.py
+++ b/testing/vcs/test_vcs_isoline_extend_attributes.py
@@ -1,0 +1,14 @@
+import cdms2
+import vcs
+import testing.regression as regression
+
+x = regression.init()
+isoline = vcs.createisoline()
+f = cdms2.open(vcs.sample_data + '/clt.nc')
+s = f("clt")
+isoline.line = ["dash-dot"]
+isoline.linecolors = [250]
+isoline.linewidths = [5]
+x.plot(s, isoline)
+fnm = "test_vcs_isoline_extend_attributes.png"
+regression.run(x, fnm)

--- a/testing/vcs/test_vcs_isoline_numpy.py
+++ b/testing/vcs/test_vcs_isoline_numpy.py
@@ -1,13 +1,10 @@
 import os, sys, cdms2, vcs, testing.regression as regression
 
 x = regression.init()
-x.setantialiasing(0)
-x.setbgoutputdimensions(1200,1091,units="pixels")
-x.drawlogooff()
 fnm = os.path.join(vcs.sample_data,'clt.nc')
 f = cdms2.open(fnm)
 s = f("clt")
 gm = x.createisofill()
-x.plot(s.filled(),gm,bg=1)
+x.plot(s.filled(),gm)
 fnm = "test_vcs_isoline_numpy.png"
 regression.run(x, fnm)


### PR DESCRIPTION
…xisting attribute list

If there are no attributes in the list, we choose
default values: linewidth=1, linestyle='solid', linecolor='black'