### PR TITLE
Fix not tuple instance condition for axis getitem call

### DIFF
--- a/Packages/cdms2/Lib/axis.py
+++ b/Packages/cdms2/Lib/axis.py
@@ -2011,8 +2011,8 @@ class FileAxis(AbstractAxis):
             else:
                 if isinstance(key, int) and key >= len(self):
                     raise IndexError, 'Index out of bounds: %d' % key
-                    if isinstance(key, tuple):
-                        key=(key,)
+                if not isinstance(key, tuple):
+                    key=(key,)
                 return apply(self._obj_.getitem, key)
         if self._data_ is None:
             self._data_=self.getData()


### PR DESCRIPTION
Wrong indentation and logic should say __NOT__ tuple instance in order to create a tuple.