### PR TITLE
Adds support for gettextextent()

### DIFF
--- a/Packages/vcs/vcs/VTKPlots.py
+++ b/Packages/vcs/vcs/VTKPlots.py
@@ -1254,7 +1254,8 @@ class VTKVCSBackend(object):
         from vtk_ui.text import text_dimensions
         
         text_property = vtk.vtkTextProperty()
-        win_size = self.renWin.GetSize()
+        info = self.canvasinfo()
+        win_size = info["width"], info["height"]
         vcs2vtk.prepTextProperty(text_property, win_size, to=textorientation, tt=texttable)
         
         dpi = self.renWin.GetDPI()

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -1088,6 +1088,13 @@ cdat_add_test(test_vcs_no_continents
   ${BASELINE_DIR}/test_vcs_no_continents.png
 )
 
+cdat_add_test(test_vcs_textextents
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_textextents.py
+  ${BASELINE_DIR}/test_textextents.png
+)
+
+
 
 add_subdirectory(vtk_ui)
 add_subdirectory(editors)

--- a/testing/vcs/test_vcs_textextents.py
+++ b/testing/vcs/test_vcs_textextents.py
@@ -1,0 +1,21 @@
+import os, sys, numpy, cdms2, MV2, vcs, testing.regression as regression
+
+# We have to specify the geometry to make sure that the size of the canvas doesn't change between the init and the plot functions
+x = regression.init(bg=True, geometry=(1200,1091))
+text = x.createtext()
+text.string = ["A very very very very long string", "A\nmult-line\nstring", "Short"]
+# Use any value for initial; then we'll manually "right align" using the text extents
+text.x = [.1]
+text.y = [.1, .5, .9]
+
+# This function only gets the extents for the *current* size
+extents = x.gettextextent(text)
+# Now we'll manually populate this with the desired values
+text.x = []
+for min_x, max_x, min_y, max_y in extents:
+    w = max_x - min_x
+    #h = max_y - min_y
+    text.x.append(1 - w)
+
+x.plot(text, bg=1)
+regression.run(x, "test_textextents.png")


### PR DESCRIPTION
Adds an implementation to the stubbed-out method `gettextextent` on the backend. Will return a list of [xmin, xmax, ymin, ymax] coordinates for each string in the `texttable` in VCS coordinates (0-1). Also adds a test, with matching testdata at UV-CDAT/uvcdat-testdata#147