### PR TITLE
Ignore trailing whitespace checks for json test files

### DIFF
--- a/testing/vcs/.gitattributes
+++ b/testing/vcs/.gitattributes
@@ -1,0 +1,1 @@
+*.json        -whitespace


### PR DESCRIPTION
This tells LLNLBot to ignore json files when performing
whitespace hook checks