### PR TITLE
Fixed addfont, added tests

### DIFF
--- a/Packages/vcs/vcs/Canvas.py
+++ b/Packages/vcs/vcs/Canvas.py
@@ -5369,41 +5369,51 @@ Options:::
         return vcs.getcolormap(Cp_name_src)
     getcolormap.__doc__ = vcs.manageElements.getcolormap.__doc__
 
-    def addfont(self, path, name=""):
+    def addfont(self, path, name=None, recursive=False):
         """
         Add a font to VCS.
 
-    :param path: Path to the font file you wish to add (must be .ttf)
+    :param path: Path to the font file you wish to add (must be .ttf) or directory you want to search through.
     :type path: str
 
     :param name: Name to use to represent the font.
     :type name: str
+
+    :param recursive: If path is a directory, whether to search it recursively or not.
+    :type recursive: bool
 """
         if not os.path.exists(path):
             raise ValueError('Error -  The font path does not exists')
         if os.path.isdir(path):
+            if name == 'r':
+                warnings.warn("Recursive font addition via the name property has been deprecated. Please use the recursive keyword argument instead.")
+                recursive = True
+                name = None
             dir_files = []
             files = []
-            if name == "":
+            if not recursive:
                 subfiles = os.listdir(path)
                 for file in subfiles:
                     dir_files.append(os.path.join(path, file))
-            elif name == 'r':
+            elif recursive:
                 for root, dirs, subfiles in os.walk(path):
                     for file in subfiles:
                         dir_files.append(os.path.join(root, file))
             for f in dir_files:
                 if f.lower()[-3:]in ['ttf', 'pfa', 'pfb']:
-                    files.append([f, ""])
+                    files.append([f, None])
         else:
             files = [[path, name], ]
 
         nms = []
         for f in files:
             fnm, name = f
+            if name is None:
+                name = os.path.splitext(os.path.basename(fnm))[0]
             i = max(vcs.elements["fontNumber"].keys()) + 1
             vcs.elements["font"][name] = fnm
             vcs.elements["fontNumber"][i] = name
+            nms.append(name)
         if len(nms) == 0:
             raise vcsError('No font Loaded')
         elif len(nms) > 1:

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -983,6 +983,16 @@ cdat_add_test(test_vcs_colorpicker_selection
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_colorpicker_selection.py
 )
 
+cdat_add_test(test_vcs_addfont
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_addfont.py
+)
+
+cdat_add_test(test_vcs_addfont_directory
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_addfont_directory.py
+)
+
 cdat_add_test(test_vcs_configurator_click_text
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_configurator_click_text.py

--- a/testing/vcs/test_vcs_addfont.py
+++ b/testing/vcs/test_vcs_addfont.py
@@ -1,0 +1,14 @@
+import vcs, os
+
+x = vcs.init()
+font_dir = os.path.dirname(vcs.elements["font"]["Adelon"])
+default_fonts = 0
+
+for font in vcs.elements["font"].values():
+    if font.startswith(font_dir):
+        default_fonts += 1
+
+# Test adding a single font.
+font_path = os.path.join(font_dir, "Adelon_Regular.ttf")
+new_font_name = x.addfont(font_path)
+assert new_font_name == "Adelon_Regular"

--- a/testing/vcs/test_vcs_addfont_directory.py
+++ b/testing/vcs/test_vcs_addfont_directory.py
@@ -1,0 +1,14 @@
+import vcs, os
+
+x = vcs.init()
+font_dir = os.path.dirname(vcs.elements["font"]["Adelon"])
+
+orig_fonts = set()
+
+for font in vcs.elements["font"].values():
+    if font.startswith(font_dir):
+        orig_fonts.add(font)
+
+# Test adding a directory of fonts.
+all_the_new_fonts = set(x.addfont(font_dir))
+assert len(all_the_new_fonts) == len(orig_fonts)


### PR DESCRIPTION
This fixes an old broken function that adds fonts to UV-CDAT, and makes the behavior a bit more sensible. You now can pass in just a path, and files will be added based on the filename (if you do not provide a name). Also no longer supports the `"r"` name, which previously made it magically recurse through a directory in search of font files, but instead takes a `recursive` argument that is true/false (defaults to false). I also added two tests to cover most of the functionality.