### PR TITLE
Fix bug with orthographic projection

### DIFF
--- a/Packages/vcs/vcs/vcs2vtk.py
+++ b/Packages/vcs/vcs/vcs2vtk.py
@@ -601,7 +601,7 @@ def apply_proj_parameters(pd, projection, x1, x2, y1, y2):
                 centerlongitude = float(x1 + x2) / 2.0
             else:
                 centerlongitude = projection.centerlongitude
-            pd.SetOptionalParameter("lon_0", str(centerlongitude))
+            pd.SetCentralMeridian(centerlongitude)
         if (hasattr(projection, 'originlatitude')):
             if (numpy.allclose(projection.originlatitude, 1e+20)):
                 originlatitude = float(y1 + y2) / 2.0

--- a/testing/vcs/CMakeLists.txt
+++ b/testing/vcs/CMakeLists.txt
@@ -1101,6 +1101,12 @@ cdat_add_test(test_vcs_no_continents
   ${BASELINE_DIR}/test_vcs_no_continents.png
 )
 
+cdat_add_test(test_vcs_center_longitude
+  "${PYTHON_EXECUTABLE}"
+  ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_center_longitude.py
+  ${BASELINE_DIR}/test_vcs_center_longitude.png
+)
+
 cdat_add_test(test_vcs_textextents
   "${PYTHON_EXECUTABLE}"
   ${cdat_SOURCE_DIR}/testing/vcs/test_vcs_textextents.py


### PR DESCRIPTION
This makes it so the `centerlongitude` attribute on orthographic projections actually works. Not entirely clear why the existing code didn't behave appropriately, `"lon_0"` is right according to the proj4 documentation, but this works right in VCS. Goes with UV-CDAT/uvcdat-testdata#151